### PR TITLE
Add Better Exception Handling For Missing Encryption Library in client.p...

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -44,8 +44,8 @@ try:
   HAS_CRYPTO = True
   if crypt.OpenSSLVerifier is not None:
     HAS_OPENSSL = True
-except ImportError:
-  pass
+except ImportError as e:
+  raise e
 
 try:
   from urlparse import parse_qsl


### PR DESCRIPTION
The current exception simply passes without raising a reason for the exception:

from oauth2client.client import SignedJwtAssertionCredentials
ImportError: cannot import name SignedJwtAssertionCredentials

This is due to line 42 - 48 of client.py:

try:
from oauth2client import crypt
HAS_CRYPTO = True
if crypt.OpenSSLVerifier is not None:
HAS_OPENSSL = True
except ImportError:
pass

I suggest modifying this to:

try:
from oauth2client import crypt
HAS_CRYPTO = True
if crypt.OpenSSLVerifier is not None:
HAS_OPENSSL = True
except ImportError as e:
raise e

This way a real exception is thrown and can be solved easier:

from oauth2client.client import SignedJwtAssertionCredentials

/Users/Alexander/.virtualenvs/tubehunter/lib/python2.7/site-packages/oauth2client/client.py in ()
46 HAS_OPENSSL = True
47 except ImportError as e:
---> 48 raise e
49 
50 try:

ImportError: No encryption library found. Please install either PyOpenSSL, or PyCrypto 2.6 or later
