### PR TITLE
Modify the OAuth2Credentials.get_access_token() method.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -629,7 +629,14 @@ class OAuth2Credentials(Credentials):
     self.store = store
 
   def _expires_in(self):
-    """Return the number of seconds until this token expires."""
+    """Return the number of seconds until this token expires.
+    
+    If token_expiry is in the past, this method will return 0, meaning the
+    token has already expired.
+    If token_expiry is None, this method will return None. Note that returning
+    0 in such a case would not be fair: the token may still be valid;
+    we just don't know anything about it. 
+    """
     if self.token_expiry:
       now = datetime.datetime.utcnow()
       if self.token_expiry > now:

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -31,6 +31,7 @@ import time
 import urllib
 import urlparse
 
+from collections import namedtuple
 from oauth2client import GOOGLE_AUTH_URI
 from oauth2client import GOOGLE_REVOKE_URI
 from oauth2client import GOOGLE_TOKEN_URI
@@ -74,6 +75,9 @@ SERVICE_ACCOUNT = 'service_account'
 
 # The environment variable pointing the file with local Default Credentials.
 GOOGLE_CREDENTIALS_DEFAULT = 'GOOGLE_CREDENTIALS_DEFAULT'
+
+# The access token along with the seconds in which it expires.
+AccessTokenInfo = namedtuple('AccessTokenInfo', ['access_token', 'expires_in'])
 
 class Error(Exception):
   """Base error for this module."""
@@ -609,7 +613,8 @@ class OAuth2Credentials(Credentials):
       if not http:
         http = httplib2.Http()
       self.refresh(http)
-    return {'access_token': self.access_token, 'expires_in': self._expires_in()}
+    return AccessTokenInfo(access_token=self.access_token,
+                           expires_in=self._expires_in())
 
   def set_store(self, store):
     """Set the Storage for the credential.

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -629,7 +629,7 @@ class OAuth2Credentials(Credentials):
     self.store = store
 
   def _expires_in(self):
-    """Get in how many seconds does the token expire."""
+    """Return the number of seconds until this token expires."""
     if self.token_expiry:
       now = datetime.datetime.utcnow()
       if self.token_expiry > now:
@@ -637,6 +637,8 @@ class OAuth2Credentials(Credentials):
         return int(round(time_delta.days * 86400.0 +
                          time_delta.seconds +
                          time_delta.microseconds * 0.000001))
+      else:
+        return 0
 
   def _updateFromCredential(self, other):
     """Update this Credential from another instance."""

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -634,9 +634,9 @@ class OAuth2Credentials(Credentials):
       now = datetime.datetime.utcnow()
       if self.token_expiry > now:
         time_delta = self.token_expiry - now
-        return int(round(time_delta.days * 86400.0 +
-                         time_delta.seconds +
-                         time_delta.microseconds * 0.000001))
+        # TODO(orestica): return time_delta.total_seconds()
+        # once dropping support for Python 2.6
+        return time_delta.days * 86400 + time_delta.seconds
       else:
         return 0
 

--- a/tests/test_appengine.py
+++ b/tests/test_appengine.py
@@ -245,8 +245,8 @@ class TestAppAssertionCredentials(unittest.TestCase):
 
     credentials = AppAssertionCredentials(['dummy_scope'])
     token = credentials.get_access_token()
-    self.assertEqual('a_token_123', token['access_token'])
-    self.assertEqual(None, token['expires_in'])
+    self.assertEqual('a_token_123', token.access_token)
+    self.assertEqual(None, token.expires_in)
 
 
 class TestFlowModel(db.Model):

--- a/tests/test_appengine.py
+++ b/tests/test_appengine.py
@@ -245,7 +245,8 @@ class TestAppAssertionCredentials(unittest.TestCase):
 
     credentials = AppAssertionCredentials(['dummy_scope'])
     token = credentials.get_access_token()
-    self.assertEqual('a_token_123', token)
+    self.assertEqual('a_token_123', token['access_token'])
+    self.assertEqual(None, token['expires_in'])
 
 
 class TestFlowModel(db.Model):

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -126,8 +126,8 @@ class AssertionCredentialsTests(unittest.TestCase):
     http.request = httplib2_request
 
     token = credentials.get_access_token(http=http)
-    self.assertEqual('this-is-a-token', token['access_token'])
-    self.assertEqual(None, token['expires_in'])
+    self.assertEqual('this-is-a-token', token.access_token)
+    self.assertEqual(None, token.expires_in)
 
     m.UnsetStubs()
     m.VerifyAll()

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -125,8 +125,9 @@ class AssertionCredentialsTests(unittest.TestCase):
     http = httplib2.Http()
     http.request = httplib2_request
 
-    self.assertEquals('this-is-a-token',
-                      credentials.get_access_token(http=http))
+    token = credentials.get_access_token(http=http)
+    self.assertEqual('this-is-a-token', token['access_token'])
+    self.assertEqual(None, token['expires_in'])
 
     m.UnsetStubs()
     m.VerifyAll()

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -583,8 +583,9 @@ class BasicCredentialsTests(unittest.TestCase):
     self.assertEqual('foobar', instance.token_response)
 
   def test_get_access_token(self):
-    token_response_first = {'access_token': 'first_token', 'expires_in': 1}
-    token_response_second = {'access_token': 'second_token', 'expires_in': 1}
+    S = 2  # number of seconds in which the token expires
+    token_response_first = {'access_token': 'first_token', 'expires_in': S}
+    token_response_second = {'access_token': 'second_token', 'expires_in': S}
     http = HttpMockSequence([
         ({'status': '200'}, simplejson.dumps(token_response_first)),
         ({'status': '200'}, simplejson.dumps(token_response_second)),
@@ -592,22 +593,22 @@ class BasicCredentialsTests(unittest.TestCase):
 
     token = self.credentials.get_access_token(http=http)
     self.assertEqual('first_token', token.access_token)
-    self.assertEqual(1, token.expires_in)
+    self.assertEqual(S - 1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
     token = self.credentials.get_access_token(http=http)
     self.assertEqual('first_token', token.access_token)
-    self.assertEqual(1, token.expires_in)
+    self.assertEqual(S - 1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
-    time.sleep(1)
+    time.sleep(S)
     self.assertTrue(self.credentials.access_token_expired)
 
     token = self.credentials.get_access_token(http=http)
     self.assertEqual('second_token', token.access_token)
-    self.assertEqual(1, token.expires_in)
+    self.assertEqual(S - 1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_second, self.credentials.token_response)
 

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -591,14 +591,14 @@ class BasicCredentialsTests(unittest.TestCase):
     ])
 
     token = self.credentials.get_access_token(http=http)
-    self.assertEqual('first_token', token['access_token'])
-    self.assertEqual(1, token['expires_in'])
+    self.assertEqual('first_token', token.access_token)
+    self.assertEqual(1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
     token = self.credentials.get_access_token(http=http)
-    self.assertEqual('first_token', token['access_token'])
-    self.assertEqual(1, token['expires_in'])
+    self.assertEqual('first_token', token.access_token)
+    self.assertEqual(1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
@@ -606,8 +606,8 @@ class BasicCredentialsTests(unittest.TestCase):
     self.assertTrue(self.credentials.access_token_expired)
 
     token = self.credentials.get_access_token(http=http)
-    self.assertEqual('second_token', token['access_token'])
-    self.assertEqual(1, token['expires_in'])
+    self.assertEqual('second_token', token.access_token)
+    self.assertEqual(1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_second, self.credentials.token_response)
 

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -590,21 +590,24 @@ class BasicCredentialsTests(unittest.TestCase):
         ({'status': '200'}, simplejson.dumps(token_response_second)),
     ])
 
-    self.assertEqual('first_token',
-                     self.credentials.get_access_token(http=http))
+    token = self.credentials.get_access_token(http=http)
+    self.assertEqual('first_token', token['access_token'])
+    self.assertEqual(1, token['expires_in'])
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
-    self.assertEqual('first_token',
-                     self.credentials.get_access_token(http=http))
+    token = self.credentials.get_access_token(http=http)
+    self.assertEqual('first_token', token['access_token'])
+    self.assertEqual(1, token['expires_in'])
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
     time.sleep(1)
     self.assertTrue(self.credentials.access_token_expired)
 
-    self.assertEqual('second_token',
-                     self.credentials.get_access_token(http=http))
+    token = self.credentials.get_access_token(http=http)
+    self.assertEqual('second_token', token['access_token'])
+    self.assertEqual(1, token['expires_in'])
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_second, self.credentials.token_response)
 

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -102,14 +102,14 @@ class ServiceAccountCredentialsTests(unittest.TestCase):
     ])
 
     token = self.credentials.get_access_token(http=http)
-    self.assertEqual('first_token', token['access_token'])
-    self.assertEqual(1, token['expires_in'])  
+    self.assertEqual('first_token', token.access_token)
+    self.assertEqual(1, token.expires_in)  
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
     token = self.credentials.get_access_token(http=http)
-    self.assertEqual('first_token', token['access_token'])
-    self.assertEqual(1, token['expires_in'])
+    self.assertEqual('first_token', token.access_token)
+    self.assertEqual(1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
@@ -117,7 +117,7 @@ class ServiceAccountCredentialsTests(unittest.TestCase):
     self.assertTrue(self.credentials.access_token_expired)
 
     token = self.credentials.get_access_token(http=http)
-    self.assertEqual('second_token', token['access_token'])
-    self.assertEqual(1, token['expires_in'])
+    self.assertEqual('second_token', token.access_token)
+    self.assertEqual(1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_second, self.credentials.token_response)

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -94,8 +94,9 @@ class ServiceAccountCredentialsTests(unittest.TestCase):
     self.assertEqual('dummy_scope', new_credentials._scopes)
 
   def test_access_token(self):
-    token_response_first = {'access_token': 'first_token', 'expires_in': 1}
-    token_response_second = {'access_token': 'second_token', 'expires_in': 1}
+    S = 2  # number of seconds in which the token expires
+    token_response_first = {'access_token': 'first_token', 'expires_in': S}
+    token_response_second = {'access_token': 'second_token', 'expires_in': S}
     http = HttpMockSequence([
         ({'status': '200'}, simplejson.dumps(token_response_first)),
         ({'status': '200'}, simplejson.dumps(token_response_second)),
@@ -103,21 +104,21 @@ class ServiceAccountCredentialsTests(unittest.TestCase):
 
     token = self.credentials.get_access_token(http=http)
     self.assertEqual('first_token', token.access_token)
-    self.assertEqual(1, token.expires_in)  
+    self.assertEqual(S - 1, token.expires_in)  
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
     token = self.credentials.get_access_token(http=http)
     self.assertEqual('first_token', token.access_token)
-    self.assertEqual(1, token.expires_in)
+    self.assertEqual(S - 1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
-    time.sleep(1)
+    time.sleep(S)
     self.assertTrue(self.credentials.access_token_expired)
 
     token = self.credentials.get_access_token(http=http)
     self.assertEqual('second_token', token.access_token)
-    self.assertEqual(1, token.expires_in)
+    self.assertEqual(S - 1, token.expires_in)
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_second, self.credentials.token_response)

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -100,21 +100,24 @@ class ServiceAccountCredentialsTests(unittest.TestCase):
         ({'status': '200'}, simplejson.dumps(token_response_first)),
         ({'status': '200'}, simplejson.dumps(token_response_second)),
     ])
-  
-    self.assertEqual('first_token',
-                     self.credentials.get_access_token(http=http))
+
+    token = self.credentials.get_access_token(http=http)
+    self.assertEqual('first_token', token['access_token'])
+    self.assertEqual(1, token['expires_in'])  
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
-    self.assertEqual('first_token',
-                     self.credentials.get_access_token(http=http))
+    token = self.credentials.get_access_token(http=http)
+    self.assertEqual('first_token', token['access_token'])
+    self.assertEqual(1, token['expires_in'])
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_first, self.credentials.token_response)
 
     time.sleep(1)
     self.assertTrue(self.credentials.access_token_expired)
 
-    self.assertEqual('second_token',
-                     self.credentials.get_access_token(http=http))
+    token = self.credentials.get_access_token(http=http)
+    self.assertEqual('second_token', token['access_token'])
+    self.assertEqual(1, token['expires_in'])
     self.assertFalse(self.credentials.access_token_expired)
     self.assertEqual(token_response_second, self.credentials.token_response)


### PR DESCRIPTION
Modify the OAuth2Credentials.get_access_token() method to return the expiration information, in addition to the access token.

This is done in preparation for integrating the Google Default Credentials into the dev_appserver.py from App Engine SDK.
