### PR TITLE
Update django to 1.6.5

### DIFF
--- a/tests/test_django_orm.py
+++ b/tests/test_django_orm.py
@@ -32,7 +32,7 @@ import unittest
 # Ensure that if app engine is available, we use the correct django from it
 try:
   from google.appengine.dist import use_library
-  use_library('django', '1.2')
+  use_library('django', '1.5')
 except ImportError:
   pass
 
@@ -41,7 +41,8 @@ from oauth2client.client import Flow
 
 # Mock a Django environment
 os.environ['DJANGO_SETTINGS_MODULE'] = 'django_settings'
-sys.modules['django_settings'] = imp.new_module('django_settings')
+sys.modules['django_settings'] = django_settings = imp.new_module('django_settings')
+django_settings.SECRET_KEY = 'xyzzy'
 
 from oauth2client.django_orm import CredentialsField
 from oauth2client.django_orm import FlowField

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps = keyring
        mox
        pyopenssl
        pycrypto==2.6
-       django==1.2
+       django==1.6.5
        webtest
        nose
 setenv = PYTHONPATH=../google_appengine

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps = keyring
        mox
        pyopenssl
        pycrypto==2.6
-       django==1.6.5
+       django>=1.5,<1.6
        webtest
        nose
 setenv = PYTHONPATH=../google_appengine


### PR DESCRIPTION
Before starting Python 3 support, test dependencies should be
updated to version supporting Python 3.
