### PR TITLE
GCE VM needs the Compute API enabled

### DIFF
--- a/samples/call_compute_service.py
+++ b/samples/call_compute_service.py
@@ -1,6 +1,8 @@
 # To be used to test GoogleCredentials.get_application_default()
 # from local machine and GCE.
-# The GCE virtual machine needs to have the Compute API enabled.
+# The GCE virtual machine needs to have both service account and
+# Compute API enabled.
+# See:  https://developers.google.com/compute/docs/authentication
 
 from googleapiclient.discovery import build
 from oauth2client.client import GoogleCredentials

--- a/samples/call_compute_service.py
+++ b/samples/call_compute_service.py
@@ -1,5 +1,6 @@
 # To be used to test GoogleCredentials.get_application_default()
 # from local machine and GCE.
+# The GCE virtual machine needs to have the Compute API enabled.
 
 from googleapiclient.discovery import build
 from oauth2client.client import GoogleCredentials


### PR DESCRIPTION
Added a comment emphasizing that the GCE VM needs to have the Compute API enabled.
