### PR TITLE
Unmark as invalid when token can be refreshed

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -742,6 +742,9 @@ class OAuth2Credentials(Credentials):
             seconds=int(d['expires_in'])) + datetime.datetime.utcnow()
       else:
         self.token_expiry = None
+      # On temporary refresh errors, the user does not actually have to
+      # re-authorize, so we unflag here.
+      self.invalid = False
       if self.store:
         self.store.locked_put(self)
     else:


### PR DESCRIPTION
It is totally possible that the server (in a bad state) responds temporarily with an status!=200 and on a retry actually refreshes the token. So we need to reset the flag `self.invalid`.
