### PR TITLE
Handle response bytes in OAuth2Credentials

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -757,8 +757,10 @@ class OAuth2Credentials(Credentials):
     resp, content = http_request(
         self.token_uri, method='POST', body=body, headers=headers)
     if resp.status == 200:
-      # TODO(jcgregorio) Raise an error if loads fails?
-      d = simplejson.loads(content)
+      try:
+        d = simplejson.loads(content)
+      except TypeError:
+        d = simplejson.loads(content.decode('utf-8'))
       self.token_response = d
       self.access_token = d['access_token']
       self.refresh_token = d.get('refresh_token', self.refresh_token)


### PR DESCRIPTION
I'm not sure how `simplejson.loads` slipped into this particular spot.

[In master](https://github.com/google/oauth2client/blob/master/oauth2client/client.py#L735) it is `json.loads` which would work just fine here.  I am unable to pinpoint where that was changed.

At any rate, `simplejson` wants a string where `json` would have wanted bytes so we have to convert the response data.

I noticed in #34 (upon which this branch is based) there is a lot of try/except going on with json decoding.  I don't know what the anticipated edge cases are, but we may be over-hacking it.

Regardless, this PR makes OAuth2Credentials usable along with the other objects that depend on it (e.g. SignedJwtAssertionCredentials)

/cc @pferate
