### PR TITLE
Use redirect_uri from client_secrets.json #46

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1864,7 +1864,6 @@ def flow_from_clientsecrets(filename, scope, redirect_uri=None,
     client_type, client_info = clientsecrets.loadfile(filename, cache=cache)
     if client_type in (clientsecrets.TYPE_WEB, clientsecrets.TYPE_INSTALLED):
       constructor_kwargs = {
-          'redirect_uri': redirect_uri,
           'auth_uri': client_info['auth_uri'],
           'token_uri': client_info['token_uri'],
           'login_hint': login_hint,
@@ -1874,9 +1873,11 @@ def flow_from_clientsecrets(filename, scope, redirect_uri=None,
         constructor_kwargs['revoke_uri'] = revoke_uri
       if device_uri is not None:
         constructor_kwargs['device_uri'] = device_uri
+      if not redirect_uri and len(client_info['redirect_uris']) > 0:
+          redirect_uri = client_info['redirect_uris'][0]
       return OAuth2WebServerFlow(
           client_info['client_id'], client_info['client_secret'],
-          scope, **constructor_kwargs)
+          scope, redirect_uri=redirect_uri, **constructor_kwargs)
 
   except clientsecrets.InvalidClientSecretsError:
     if message:

--- a/tests/data/client_secrets.json
+++ b/tests/data/client_secrets.json
@@ -2,7 +2,7 @@
   "web": {
     "client_id": "foo_client_id",
     "client_secret": "foo_client_secret",
-    "redirect_uris": [],
+    "redirect_uris": ["https://example.com/oauth2callback"],
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://accounts.google.com/o/oauth2/token",
     "revoke_uri": "https://accounts.google.com/o/oauth2/revoke"

--- a/tests/data/client_secrets_no_redirect_uri.json
+++ b/tests/data/client_secrets_no_redirect_uri.json
@@ -1,0 +1,10 @@
+{
+  "web": {
+    "client_id": "foo_client_id",
+    "client_secret": "foo_client_secret",
+    "redirect_uris": [],
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://accounts.google.com/o/oauth2/token",
+    "revoke_uri": "https://accounts.google.com/o/oauth2/revoke"
+  }
+}

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -963,6 +963,32 @@ class FlowFromCachedClientsecrets(unittest.TestCase):
     self.assertEquals('foo_client_secret', flow.client_secret)
 
 
+class FlowFromClientsecrets(unittest.TestCase):
+
+    def test_flow_from_clientsecrets_has_redirect_uri(self):
+        existing_file = 'client_secrets.json'
+        client_type, client_info = _loadfile(datafile(existing_file))
+        flow = flow_from_clientsecrets(datafile(existing_file), '')
+
+        assert flow.redirect_uri == client_info['redirect_uris'][0]
+
+    def test_flow_from_clientsecrets_overwrite_redirect_uri(self):
+        existing_file = 'client_secrets.json'
+        expected_redirect_uri = 'https://example.com/abc'
+        client_type, client_info = _loadfile(datafile(existing_file))
+        flow = flow_from_clientsecrets(datafile(existing_file), '',
+                                       redirect_uri=expected_redirect_uri)
+
+        assert flow.redirect_uri != client_info['redirect_uris'][0]
+        assert flow.redirect_uri == expected_redirect_uri
+
+    def test_flow_from_clientsecrets_has_no_redirect_uri(self):
+        existing_file = 'client_secrets_no_redirect_uri.json'
+        flow = flow_from_clientsecrets(datafile(existing_file), '')
+
+        assert flow.redirect_uri is None
+
+
 class CredentialsFromCodeTests(unittest.TestCase):
   def setUp(self):
     self.client_id = 'client_id_abc'


### PR DESCRIPTION
Clientsecrets file downloaded from Google APIs project already contains redirect_uri and one doesn't need to provide it separately.

This PR keeps old functionality, when `redirect_uri` can be provided as an argument to `flow_from_clientsecrets`.

Given client_secrets.json that contains redirect uri:

```
# client_secrets.json
{
    "web":
    {
        "client_id":"blah-blah",
        "client_secret":"blah-blah",
        "client_email":"blah-blah",
        "redirect_uris":["https://example.com/oauth2callback"],
    }
}
```

The following two lines of code have the same behavior:

```
redirect_uri = 'https://example.com/oauth2callback
# old way:
flow = flow_from_clientsecrets('client_secrets.json', scopes, redirect_uri=redirect_uri)
# new way:
flow = flow_from_clientsecrets('client_secrets.json', scopes)
```
