### PR TITLE
Add google_credentials_json and accompanying tests.

### DIFF
--- a/oauth2client/google_credentials_json.py
+++ b/oauth2client/google_credentials_json.py
@@ -1,0 +1,161 @@
+"""Utilities for reading and writing Google Credentials models.
+
+This Google Credential JSON model provides a common format for reading and
+validating credentials for use in calling Google APIs. Notably, the format is
+used for Google Application Default Credentials as described here:
+https://developers.google.com/accounts/docs/application-default-credentials
+"""
+
+
+import json
+from oauth2client import GOOGLE_REVOKE_URI
+from oauth2client import GOOGLE_TOKEN_URI
+
+
+class Error(Exception):
+  """Base error for this module."""
+
+
+class InvalidCredentialModelError(Error):
+  """Supplied arguments would not produce a valid credential object."""
+
+
+class GoogleCredentialsJson(object):
+  """Wrapper for loading and serializing Google Credentials JSON objects."""
+
+  # Properties which describe various types of default credential model objects.
+  TYPE_SERVICE_ACCOUNT = 'service_account'
+  TYPE_AUTHORIZED_USER = 'authorized_user'
+
+  TYPE_FIELD_NAME = 'type'
+  CLIENT_ID_FIELD_NAME = 'client_id'
+  CLIENT_EMAIL_FIELD_NAME = 'client_email'
+  PRIVATE_KEY_ID_FIELD_NAME = 'private_key_id'
+  PRIVATE_KEY_FIELD_NAME = 'private_key'
+  CLIENT_SECRET_FIELD_NAME = 'client_secret'
+  REFRESH_TOKEN_FIELD_NAME = 'refresh_token'
+
+  # optional field names
+  TOKEN_URI_FIELD_NAME = 'token_uri'
+  REVOKE_URI_FIELD_NAME = 'revoke_uri'
+
+  _REQUIRED_SERVICE_ACCOUNT_FIELDS = set(
+      [TYPE_FIELD_NAME, CLIENT_ID_FIELD_NAME, CLIENT_EMAIL_FIELD_NAME,
+       PRIVATE_KEY_ID_FIELD_NAME, PRIVATE_KEY_FIELD_NAME])
+  _REQUIRED_AUTHORIZED_USER_FIELDS = set(
+      [TYPE_FIELD_NAME, CLIENT_ID_FIELD_NAME, CLIENT_SECRET_FIELD_NAME,
+       REFRESH_TOKEN_FIELD_NAME])
+
+  @classmethod
+  def _validate_credential_object(cls, credential_object):
+    """Private method for validating Google Credentials."""
+
+    if credential_object is None:
+      raise InvalidCredentialModelError('Empty credential object.')
+
+    credential_type = credential_object[cls.TYPE_FIELD_NAME]
+
+    cls._check_credential_type(credential_type)
+
+    if credential_type == cls.TYPE_AUTHORIZED_USER:
+      missing_fields = cls._REQUIRED_AUTHORIZED_USER_FIELDS.difference(
+          credential_object.keys())
+    if credential_type == cls.TYPE_SERVICE_ACCOUNT:
+      missing_fields = cls._REQUIRED_SERVICE_ACCOUNT_FIELDS.difference(
+          credential_object.keys())
+
+    if missing_fields:
+      cls._raise_exception_for_missing_fields(missing_fields)
+
+    return credential_object
+
+  @classmethod
+  def _check_credential_type(cls, credential_type):
+    if not (
+        credential_type == cls.TYPE_SERVICE_ACCOUNT or
+        credential_type == cls.TYPE_AUTHORIZED_USER):
+      cls._raise_exception_for_unknown_type()
+
+  @classmethod
+  def _set_optional_fields(cls, obj, token_uri=GOOGLE_TOKEN_URI,
+                           revoke_uri=GOOGLE_REVOKE_URI):
+    # set uri fields to default values if unspecified
+    if cls.TOKEN_URI_FIELD_NAME not in obj:
+      obj[cls.TOKEN_URI_FIELD_NAME] = token_uri
+    if cls.REVOKE_URI_FIELD_NAME not in obj:
+      obj[cls.REVOKE_URI_FIELD_NAME] = revoke_uri
+    return obj
+
+  @staticmethod
+  def _raise_exception_for_missing_fields(missing_fields):
+    raise InvalidCredentialModelError(
+        'The following field(s) must be defined: ' + ', '.join(missing_fields))
+
+  @classmethod
+  def _raise_exception_for_unknown_type(cls):
+    raise InvalidCredentialModelError(
+        "'type' field should be defined (and have one of the '" +
+        cls.TYPE_AUTHORIZED_USER + "' or '" + cls.TYPE_SERVICE_ACCOUNT +
+        "' values)")
+
+  @classmethod
+  def serialize_data(cls, credential_type=None, client_id=None,
+                     client_email=None, client_secret=None, private_key=None,
+                     private_key_id=None, refresh_token=None,
+                     token_uri=GOOGLE_TOKEN_URI, revoke_uri=GOOGLE_REVOKE_URI,
+                     include_optional_fields=False):
+    """Returns a validated string representation of a credential JSON object.
+
+    Usage:
+      serialize_data('authorized_user', client_id, client_secret, refresh_token)
+
+    Args:
+      credential_type: string, type of credential, e.g. 'authorized_user'
+      client_id: string, client identifier.
+      client_email: string, client email or service account email.
+      client_secret: string, client secret.
+      private_key: string, private key, typically, in PKCS12 or PEM format.
+      private_key_id: string, a hint for your signing key.
+      refresh_token: string, refresh token.
+      token_uri: string, URI of token endpoint.
+      revoke_uri: string, URI for revoke endpoint.
+      include_optional_fields: bool, if true include optional fields in output.
+
+    Returns:
+      a dict representation of a validated credential object
+    """
+    credential_object = {}
+
+    if credential_type is cls.TYPE_SERVICE_ACCOUNT:
+      credential_object[cls.TYPE_FIELD_NAME] = cls.TYPE_SERVICE_ACCOUNT
+      credential_object[cls.CLIENT_ID_FIELD_NAME] = client_id
+      credential_object[cls.CLIENT_EMAIL_FIELD_NAME] = client_email
+      credential_object[cls.PRIVATE_KEY_ID_FIELD_NAME] = private_key_id
+      credential_object[cls.PRIVATE_KEY_FIELD_NAME] = private_key
+      if include_optional_fields:
+        credential_object = cls._set_optional_fields(credential_object,
+                                                     token_uri, revoke_uri)
+      return cls._validate_credential_object(credential_object)
+
+    if credential_type is cls.TYPE_AUTHORIZED_USER:
+      credential_object[cls.TYPE_FIELD_NAME] = cls.TYPE_AUTHORIZED_USER
+      credential_object[cls.CLIENT_ID_FIELD_NAME] = client_id
+      credential_object[cls.CLIENT_SECRET_FIELD_NAME] = client_secret
+      credential_object[cls.REFRESH_TOKEN_FIELD_NAME] = refresh_token
+      if include_optional_fields:
+        credential_object = cls._set_optional_fields(credential_object,
+                                                     token_uri, revoke_uri)
+      return cls._validate_credential_object(credential_object)
+
+    # raise an error if no valid credential_type provided
+    cls._check_credential_type(credential_type)
+
+  @classmethod
+  def load(cls, fp):
+    obj = cls._set_optional_fields(json.load(fp))
+    return cls._validate_credential_object(obj)
+
+  @classmethod
+  def loads(cls, s):
+    obj = cls._set_optional_fields(json.loads(s))
+    return cls._validate_credential_object(obj)

--- a/tests/data/gcloud/application_default_credentials_optional_uris.json
+++ b/tests/data/gcloud/application_default_credentials_optional_uris.json
@@ -1,0 +1,11 @@
+{
+  "type": "service_account",
+  "client_id": "123",
+  "client_secret": "secret",
+  "refresh_token": "alabalaportocala",
+  "client_email": "dummy@google.com",
+  "private_key_id": "ABCDEF",
+  "private_key": "Bag Attributes\n    friendlyName: key\n    localKeyID: 22 7E 04 FC 64 48 20 83 1E C1 BD E3 F5 2F 44 7D EA 99 A5 BC\nKey Attributes: <No Attributes>\n-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDh6PSnttDsv+vi\ntUZTP1E3hVBah6PUGDWZhYgNiyW8quTWCmPvBmCR2YzuhUrY5+CtKP8UJOQico+p\noJHSAPsrzSr6YsGs3c9SQOslBmm9Fkh9/f/GZVTVZ6u5AsUmOcVvZ2q7Sz8Vj/aR\naIm0EJqRe9cQ5vvN9sg25rIv4xKwIZJ1VixKWJLmpCmDINqn7xvl+ldlUmSr3aGt\nw21uSDuEJhQlzO3yf2FwJMkJ9SkCm9oVDXyl77OnKXj5bOQ/rojbyGeIxDJSUDWE\nGKyRPuqKi6rSbwg6h2G/Z9qBJkqM5NNTbGRIFz/9/LdmmwvtaqCxlLtD7RVEryAp\n+qTGDk5hAgMBAAECggEBAMYYfNDEYpf4A2SdCLne/9zrrfZ0kphdUkL48MDPj5vN\nTzTRj6f9s5ixZ/+QKn3hdwbguCx13QbH5mocP0IjUhyqoFFHYAWxyyaZfpjM8tO4\nQoEYxby3BpjLe62UXESUzChQSytJZFwIDXKcdIPNO3zvVzufEJcfG5no2b9cIvsG\nDy6J1FNILWxCtDIqBM+G1B1is9DhZnUDgn0iKzINiZmh1I1l7k/4tMnozVIKAfwo\nf1kYjG/d2IzDM02mTeTElz3IKeNriaOIYTZgI26xLJxTkiFnBV4JOWFAZw15X+yR\n+DrjGSIkTfhzbLa20Vt3AFM+LFK0ZoXT2dRnjbYPjQECgYEA+9XJFGwLcEX6pl1p\nIwXAjXKJdju9DDn4lmHTW0Pbw25h1EXONwm/NPafwsWmPll9kW9IwsxUQVUyBC9a\nc3Q7rF1e8ai/qqVFRIZof275MI82ciV2Mw8Hz7FPAUyoju5CvnjAEH4+irt1VE/7\nSgdvQ1gDBQFegS69ijdz+cOhFxkCgYEA5aVoseMy/gIlsCvNPyw9+Jz/zBpKItX0\njGzdF7lhERRO2cursujKaoHntRckHcE3P/Z4K565bvVq+VaVG0T/BcBKPmPHrLmY\niuVXidltW7Jh9/RCVwb5+BvqlwlC470PEwhqoUatY/fPJ74srztrqJHvp1L29FT5\nsdmlJW8YwokCgYAUa3dMgp5C0knKp5RY1KSSU5E11w4zKZgwiWob4lq1dAPWtHpO\nGCo63yyBHImoUJVP75gUw4Cpc4EEudo5tlkIVuHV8nroGVKOhd9/Rb5K47Hke4kk\nBrn5a0Ues9qPDF65Fw1ryPDFSwHufjXAAO5SpZZJF51UGDgiNvDedbBgMQKBgHSk\nt7DjPhtW69234eCckD2fQS5ijBV1p2lMQmCygGM0dXiawvN02puOsCqDPoz+fxm2\nDwPY80cw0M0k9UeMnBxHt25JMDrDan/iTbxu++T/jlNrdebOXFlxlI5y3c7fULDS\nLZcNVzTXwhjlt7yp6d0NgzTyJw2ju9BiREfnTiRBAoGBAOPHrTOnPyjO+bVcCPTB\nWGLsbBd77mVPGIuL0XGrvbVYPE8yIcNbZcthd8VXL/38Ygy8SIZh2ZqsrU1b5WFa\nXUMLnGEODSS8x/GmW3i3KeirW5OxBNjfUzEF4XkJP8m41iTdsQEXQf9DdUY7X+CB\nVL5h7N0VstYhGgycuPpcIUQa\n-----END PRIVATE KEY-----\n",
+  "token_uri": "dummy_token_uri",
+  "revoke_uri": "dummy_revoke_uri"
+}

--- a/tests/test_google_credentials_json.py
+++ b/tests/test_google_credentials_json.py
@@ -1,0 +1,149 @@
+"""GoogleCredentialJson tests.
+
+Unit tests for GoogleCredentialsJson model.
+"""
+
+import os
+import unittest
+
+from oauth2client import GOOGLE_REVOKE_URI
+from oauth2client import GOOGLE_TOKEN_URI
+from oauth2client.google_credentials_json import GoogleCredentialsJson
+from oauth2client.google_credentials_json import InvalidCredentialModelError
+
+_SAMPLE_CLIENT_ID = '123'
+_SAMPLE_CLIENT_EMAIL = 'dummy@google.com'
+_SAMPLE_CLIENT_SECRET = 'secret'
+_SAMPLE_REFRESH_TOKEN = 'alabalaportocala'
+_SAMPLE_PRIVATE_KEY_ID = 'ABCDEF'
+_SAMPLE_PRIVATE_KEY = 'localKeyID: 22 7E 04 FC 64 48 20 83 1E C1...'
+_SAMPLE_TOKEN_URI = 'dummy_token_uri'
+_SAMPLE_REVOKE_URI = 'dummy_revoke_uri'
+
+
+def datafile(filename):
+  f = open(os.path.join(os.path.dirname(__file__), 'data', filename), 'r')
+  data = f.read()
+  f.close()
+  return data
+
+
+class GoogleCredentialsJsonTests(unittest.TestCase):
+
+  def setUp(self):
+    self.os_name = os.name
+
+  def test_serialize_data_unknown_type(self):
+    try:
+      GoogleCredentialsJson.serialize_data(credential_type='badtype')
+    except InvalidCredentialModelError:
+      pass  # Expected
+
+  def test_serialize_data_service_account(self):
+    cred = GoogleCredentialsJson.serialize_data(
+        credential_type=GoogleCredentialsJson.TYPE_SERVICE_ACCOUNT,
+        client_id=_SAMPLE_CLIENT_ID, client_email=_SAMPLE_CLIENT_EMAIL,
+        private_key_id=_SAMPLE_PRIVATE_KEY_ID, private_key=_SAMPLE_PRIVATE_KEY)
+    self.assertEqual(GoogleCredentialsJson.TYPE_SERVICE_ACCOUNT,
+                     cred[GoogleCredentialsJson.TYPE_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_ID,
+                     cred[GoogleCredentialsJson.CLIENT_ID_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_EMAIL,
+                     cred[GoogleCredentialsJson.CLIENT_EMAIL_FIELD_NAME])
+    self.assertEqual(_SAMPLE_PRIVATE_KEY_ID,
+                     cred[GoogleCredentialsJson.PRIVATE_KEY_ID_FIELD_NAME])
+    self.assertEqual(_SAMPLE_PRIVATE_KEY,
+                     cred[GoogleCredentialsJson.PRIVATE_KEY_FIELD_NAME])
+
+  def test_serialize_data_authorized_user(self):
+    cred = GoogleCredentialsJson.serialize_data(
+        credential_type=GoogleCredentialsJson.TYPE_AUTHORIZED_USER,
+        client_id=_SAMPLE_CLIENT_ID, client_secret=_SAMPLE_CLIENT_SECRET,
+        refresh_token=_SAMPLE_REFRESH_TOKEN)
+    self.assertEqual(GoogleCredentialsJson.TYPE_AUTHORIZED_USER,
+                     cred[GoogleCredentialsJson.TYPE_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_ID,
+                     cred[GoogleCredentialsJson.CLIENT_ID_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_SECRET,
+                     cred[GoogleCredentialsJson.CLIENT_SECRET_FIELD_NAME])
+    self.assertEqual(_SAMPLE_REFRESH_TOKEN,
+                     cred[GoogleCredentialsJson.REFRESH_TOKEN_FIELD_NAME])
+    # check that optional fields are not present
+    self.assertFalse(GoogleCredentialsJson.TOKEN_URI_FIELD_NAME in cred)
+    self.assertFalse(GoogleCredentialsJson.REVOKE_URI_FIELD_NAME in cred)
+
+  def test_serialize_data_enable_optional_fields(self):
+    cred = GoogleCredentialsJson.serialize_data(
+        credential_type=GoogleCredentialsJson.TYPE_AUTHORIZED_USER,
+        client_id=_SAMPLE_CLIENT_ID, client_secret=_SAMPLE_CLIENT_SECRET,
+        refresh_token=_SAMPLE_REFRESH_TOKEN, include_optional_fields=True)
+
+    self.assertEqual(GoogleCredentialsJson.TYPE_AUTHORIZED_USER,
+                     cred[GoogleCredentialsJson.TYPE_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_ID,
+                     cred[GoogleCredentialsJson.CLIENT_ID_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_SECRET,
+                     cred[GoogleCredentialsJson.CLIENT_SECRET_FIELD_NAME])
+    self.assertEqual(_SAMPLE_REFRESH_TOKEN,
+                     cred[GoogleCredentialsJson.REFRESH_TOKEN_FIELD_NAME])
+    # check that optional fields are present
+    self.assertEqual(GOOGLE_TOKEN_URI,
+                     cred[GoogleCredentialsJson.TOKEN_URI_FIELD_NAME])
+    self.assertEqual(GOOGLE_REVOKE_URI,
+                     cred[GoogleCredentialsJson.REVOKE_URI_FIELD_NAME])
+
+  def test_loads_success(self):
+    fn = 'application_default_credentials.json'
+    well_known_file = datafile(os.path.join('gcloud', fn))
+    cred = GoogleCredentialsJson.loads(well_known_file)
+
+    self.assertEqual(GoogleCredentialsJson.TYPE_SERVICE_ACCOUNT,
+                     cred[GoogleCredentialsJson.TYPE_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_ID,
+                     cred[GoogleCredentialsJson.CLIENT_ID_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_EMAIL,
+                     cred[GoogleCredentialsJson.CLIENT_EMAIL_FIELD_NAME])
+    self.assertEqual(_SAMPLE_PRIVATE_KEY_ID,
+                     cred[GoogleCredentialsJson.PRIVATE_KEY_ID_FIELD_NAME])
+    self.assertEqual(GOOGLE_TOKEN_URI,
+                     cred[GoogleCredentialsJson.TOKEN_URI_FIELD_NAME])
+    self.assertEqual(GOOGLE_REVOKE_URI,
+                     cred[GoogleCredentialsJson.REVOKE_URI_FIELD_NAME])
+
+  def test_load_success(self):
+    fn = 'application_default_credentials.json'
+    f = open(os.path.join(os.path.dirname(__file__), 'data', 'gcloud', fn), 'r')
+    cred = GoogleCredentialsJson.load(f)
+    f.close()
+
+    self.assertEqual(GoogleCredentialsJson.TYPE_SERVICE_ACCOUNT,
+                     cred[GoogleCredentialsJson.TYPE_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_ID,
+                     cred[GoogleCredentialsJson.CLIENT_ID_FIELD_NAME])
+    self.assertEqual(_SAMPLE_CLIENT_EMAIL,
+                     cred[GoogleCredentialsJson.CLIENT_EMAIL_FIELD_NAME])
+    self.assertEqual(_SAMPLE_PRIVATE_KEY_ID,
+                     cred[GoogleCredentialsJson.PRIVATE_KEY_ID_FIELD_NAME])
+    self.assertEqual(GOOGLE_TOKEN_URI,
+                     cred[GoogleCredentialsJson.TOKEN_URI_FIELD_NAME])
+    self.assertEqual(GOOGLE_REVOKE_URI,
+                     cred[GoogleCredentialsJson.REVOKE_URI_FIELD_NAME])
+
+  def test_loads_missing_fields(self):
+    fn = 'application_default_credentials_malformed_2.json'
+    well_known_file = datafile(os.path.join('gcloud', fn))
+    try:
+      GoogleCredentialsJson.loads(well_known_file)
+    except InvalidCredentialModelError:
+      pass  # Expected
+
+  def test_loads_verify_optional_fields(self):
+    fn = 'application_default_credentials_optional_uris.json'
+    f = open(os.path.join(os.path.dirname(__file__), 'data', 'gcloud', fn), 'r')
+    cred = GoogleCredentialsJson.load(f)
+    f.close()
+
+    self.assertEqual(_SAMPLE_TOKEN_URI,
+                     cred[GoogleCredentialsJson.TOKEN_URI_FIELD_NAME])
+    self.assertEqual(_SAMPLE_REVOKE_URI,
+                     cred[GoogleCredentialsJson.REVOKE_URI_FIELD_NAME])

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -39,7 +39,6 @@ from oauth2client.client import AccessTokenCredentials
 from oauth2client.client import AccessTokenCredentialsError
 from oauth2client.client import AccessTokenRefreshError
 from oauth2client.client import AssertionCredentials
-from oauth2client.client import AUTHORIZED_USER
 from oauth2client.client import Credentials
 from oauth2client.client import ApplicationDefaultCredentialsError
 from oauth2client.client import FlowExchangeError
@@ -51,7 +50,6 @@ from oauth2client.client import OAuth2Credentials
 from oauth2client.client import OAuth2WebServerFlow
 from oauth2client.client import OOB_CALLBACK_URN
 from oauth2client.client import REFRESH_STATUS_CODES
-from oauth2client.client import SERVICE_ACCOUNT
 from oauth2client.client import Storage
 from oauth2client.client import TokenRevokeError
 from oauth2client.client import VerifyJwtTokenError
@@ -69,6 +67,8 @@ from oauth2client.client import credentials_from_code
 from oauth2client.client import flow_from_clientsecrets
 from oauth2client.client import save_to_well_known_file
 from oauth2client.clientsecrets import _loadfile
+from oauth2client.google_credentials_json import GoogleCredentialsJson
+from oauth2client.google_credentials_json import InvalidCredentialModelError
 from oauth2client.service_account import _ServiceAccountCredentials
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -317,11 +317,11 @@ class GoogleCredentialsTests(unittest.TestCase):
     try:
       _get_application_default_credential_from_file(credentials_file)
       self.fail('An exception was expected!')
-    except ApplicationDefaultCredentialsError as error:
-      self.assertEqual("'type' field should be defined "
-                       "(and have one of the '" + AUTHORIZED_USER +
-                       "' or '" + SERVICE_ACCOUNT + "' values)",
-                       str(error))
+    except InvalidCredentialModelError as error:
+      self.assertEqual('\'type\' field should be defined (and have one of ' +
+                       'the \'' + GoogleCredentialsJson.TYPE_AUTHORIZED_USER +
+                       '\' or \'' + GoogleCredentialsJson.TYPE_SERVICE_ACCOUNT +
+                       '\' values)', str(error))
 
   def test_get_application_default_credential_from_malformed_file_2(self):
     credentials_file = datafile(
@@ -331,7 +331,7 @@ class GoogleCredentialsTests(unittest.TestCase):
     try:
       _get_application_default_credential_from_file(credentials_file)
       self.fail('An exception was expected!')
-    except ApplicationDefaultCredentialsError as error:
+    except InvalidCredentialModelError as error:
       self.assertEqual('The following field(s) must be defined: private_key_id',
                        str(error))
 
@@ -422,12 +422,12 @@ class GoogleCredentialsTests(unittest.TestCase):
       self.fail('An exception was expected!')
     except ApplicationDefaultCredentialsError as error:
       self.assertEqual(
-          "The Application Default Credentials are not available. They are "
-          "available if running in Google Compute Engine.  Otherwise, the "
-          " environment variable " + GOOGLE_APPLICATION_CREDENTIALS +
-          " must be defined pointing to a file defining the credentials. "
-          "See https://developers.google.com/accounts/docs/application-default-"
-          "credentials for more information.",
+          'The Application Default Credentials are not available. They are '
+          'available if running in Google Compute Engine.  Otherwise, the '
+          ' environment variable ' + GOOGLE_APPLICATION_CREDENTIALS +
+          ' must be defined pointing to a file defining the credentials. '
+          'See https://developers.google.com/accounts/docs/application-default-'
+          'credentials for more information.',
           str(error))
 
   def test_from_stream_service_account(self):
@@ -454,12 +454,13 @@ class GoogleCredentialsTests(unittest.TestCase):
       self.get_a_google_credentials_object().from_stream(credentials_file)
       self.fail('An exception was expected!')
     except ApplicationDefaultCredentialsError as error:
-      self.assertEqual("An error was encountered while reading json file: " +
-                       credentials_file +
-                       " (provided as parameter to the from_stream() method): "
-                       "'type' field should be defined (and have one of the '" +
-                       AUTHORIZED_USER + "' or '" + SERVICE_ACCOUNT +
-                       "' values)",
+      self.assertEqual('An error was encountered while reading json file: ' +
+                       credentials_file + ' (provided as parameter to the ' +
+                       'from_stream() method): \'type\' field should be ' +
+                       'defined (and have one of the \'' +
+                       GoogleCredentialsJson.TYPE_AUTHORIZED_USER + '\' or \'' +
+                       GoogleCredentialsJson.TYPE_SERVICE_ACCOUNT +
+                       '\' values)',
                        str(error))
 
   def test_from_stream_malformed_file_2(self):


### PR DESCRIPTION
Move validation logic from client.py to google_credential_json.
Refactor client.py and tests to use google_credential_json module.

Related to: https://github.com/google/oauth2client/issues/44
