### PR TITLE
Added error description to AccessTokenRefreshError

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -760,6 +760,8 @@ class OAuth2Credentials(Credentials):
         d = json.loads(content)
         if 'error' in d:
           error_msg = d['error']
+          if 'error_description' in d:
+            error_msg += ': ' + d['error_description']
           self.invalid = True
           if self.store:
             self.store.locked_put(self)


### PR DESCRIPTION
The JSON response returned can contain an `error_description` field that contains additional information about the error. If found, appending to the error message.
