### PR TITLE
multistore_file.py: don't write trailing whitespace in json creds

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1118,7 +1118,7 @@ def save_to_well_known_file(credentials, well_known_file=None):
   credentials_data = credentials.serialization_data
 
   with open(well_known_file, 'w') as f:
-    json.dump(credentials_data, f, sort_keys=True, indent=2)
+    json.dump(credentials_data, f, sort_keys=True, indent=2, separators=(',', ': '))
 
 
 def _get_environment_variable_file():

--- a/oauth2client/multistore_file.py
+++ b/oauth2client/multistore_file.py
@@ -327,7 +327,7 @@ class _MultiStore(object):
     if self._read_only:
       return
     self._file.file_handle().seek(0)
-    json.dump(data, self._file.file_handle(), sort_keys=True, indent=2)
+    json.dump(data, self._file.file_handle(), sort_keys=True, indent=2, separators=(',', ': '))
     self._file.file_handle().truncate()
 
   def _refresh_data_cache(self):


### PR DESCRIPTION
I've noticed this minor infelicity in 'google-cloud-sdk'
project which creates prettyprinted cred files in

```
~/.config/gcloud
~/.config/gcloud/legacy_credentials/${USER}/multistore.json
```

with trailing whitespace.

The reason is the call to 'json.dump[s](indent=2)'
without accompanying 'separators=' overrride.

Signed-off-by: Sergei Trofimovich siarheit@google.com
