### PR TITLE
Patch to keep the raw value of the OAuth2 id_token

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1838,14 +1838,14 @@ class OAuth2WebServerFlow(Flow):
 
       extracted_id_token = None
       if 'id_token' in d:
-        extracted_id_token = _extract_id_token(d['id_token'])
+        d['extracted_id_token'] = _extract_id_token(d['id_token'])
 
       logger.info('Successfully retrieved access token')
       return OAuth2Credentials(access_token, self.client_id,
                                self.client_secret, refresh_token, token_expiry,
                                self.token_uri, self.user_agent,
                                revoke_uri=self.revoke_uri,
-                               id_token=extracted_id_token,
+                               id_token=d.get('extracted_id_token', None),
                                token_response=d)
     else:
       logger.info('Failed to retrieve access token: %s', content)

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1836,15 +1836,16 @@ class OAuth2WebServerFlow(Flow):
         token_expiry = datetime.datetime.utcnow() + datetime.timedelta(
             seconds=int(d['expires_in']))
 
+      extracted_id_token = None
       if 'id_token' in d:
-        d['id_token'] = _extract_id_token(d['id_token'])
+        extracted_id_token = _extract_id_token(d['id_token'])
 
       logger.info('Successfully retrieved access token')
       return OAuth2Credentials(access_token, self.client_id,
                                self.client_secret, refresh_token, token_expiry,
                                self.token_uri, self.user_agent,
                                revoke_uri=self.revoke_uri,
-                               id_token=d.get('id_token', None),
+                               id_token=extracted_id_token,
                                token_response=d)
     else:
       logger.info('Failed to retrieve access token: %s', content)


### PR DESCRIPTION
Path to keep the raw value of the id_token in the token_reponse attribute of the OAuth2Credentials object.
This value is needed in some case, for example for the Amazon AWS Web identity federation.
See issue #64 
