### PR TITLE
Use six when checking for strings.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1806,7 +1806,7 @@ class OAuth2WebServerFlow(Flow):
 
     if code is None:
       code = device_flow_info.device_code
-    elif not isinstance(code, basestring):
+    elif not isinstance(code, six.string_types):
       if 'code' not in code:
         raise FlowExchangeError(code.get(
             'error', 'No code was supplied in the query parameters.'))

--- a/oauth2client/util.py
+++ b/oauth2client/util.py
@@ -152,11 +152,7 @@ def scopes_to_string(scopes):
   Returns:
     The scopes formatted as a single string.
   """
-  try:
-    is_string = isinstance(scopes, basestring)
-  except NameError:
-    is_string = isinstance(scopes, str)
-  if is_string:
+  if isinstance(scopes, six.string_types):
     return scopes
   else:
     return ' '.join(scopes)


### PR DESCRIPTION
`flow.step2_exchange` doesn't work under Python 3 (raises a `NameError`, since `basestring` was removed). It's best to use six when checking for string instances.
