### PR TITLE
Handle a missing argparse more gracefully.

### DIFF
--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 __all__ = ['argparser', 'run_flow', 'run', 'message_if_missing']
 
-import argparse
 import BaseHTTPServer
 import logging
 import socket
@@ -51,17 +50,25 @@ with information from the APIs Console <https://code.google.com/apis/console>.
 # argparser is an ArgumentParser that contains command-line options expected
 # by tools.run(). Pass it in as part of the 'parents' argument to your own
 # ArgumentParser.
-argparser = argparse.ArgumentParser(add_help=False)
-argparser.add_argument('--auth_host_name', default='localhost',
-                       help='Hostname when running a local web server.')
-argparser.add_argument('--noauth_local_webserver', action='store_true',
-                       default=False, help='Do not run a local web server.')
-argparser.add_argument('--auth_host_port', default=[8080, 8090], type=int,
-                       nargs='*', help='Port web server should listen on.')
-argparser.add_argument('--logging_level', default='ERROR',
-                       choices=['DEBUG', 'INFO', 'WARNING', 'ERROR',
-                                'CRITICAL'],
-                       help='Set the logging level of detail.')
+argparser = _CreateArgumentParser()
+
+def _CreateArgumentParser():
+  try:
+    import argparse
+  except ImportError:
+    return None
+  argparser = argparse.ArgumentParser(add_help=False)
+  argparser.add_argument('--auth_host_name', default='localhost',
+                         help='Hostname when running a local web server.')
+  argparser.add_argument('--noauth_local_webserver', action='store_true',
+                         default=False, help='Do not run a local web server.')
+  argparser.add_argument('--auth_host_port', default=[8080, 8090], type=int,
+                         nargs='*', help='Port web server should listen on.')
+  argparser.add_argument('--logging_level', default='ERROR',
+                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR',
+                                  'CRITICAL'],
+                         help='Set the logging level of detail.')
+  return argparser
 
 
 class ClientRedirectServer(BaseHTTPServer.HTTPServer):


### PR DESCRIPTION
Currently, if argparse isn't installed, we'll fail when trying to import
`oauth2client.tools`. Given that this module can still be useful (say for
someone using `gflags`), it seems friendlier to simply skip the one top-level
operation requiring `argparse`.

PTAL @skelterjohn 
