### PR TITLE
Add minimum version of six>=1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     'pyasn1==0.1.7',
     'pyasn1_modules==0.0.5',
     'rsa==3.1.4',
-    'six',
+    'six>=1.4.0',
 ]
 
 long_desc = """The oauth2client is a client library for OAuth 2.0."""


### PR DESCRIPTION
six.moves.urllib was introduced in 1.4.0; older versions are incompatible with oauth2client.

This pull request makes this requirement explicit.
