### PR TITLE
Refactoring _get_environment.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -33,7 +33,6 @@ from six.moves import urllib
 
 import httplib2
 from oauth2client import clientsecrets
-from oauth2client import client_settings
 from oauth2client import GOOGLE_AUTH_URI
 from oauth2client import GOOGLE_DEVICE_URI
 from oauth2client import GOOGLE_REVOKE_URI
@@ -90,6 +89,10 @@ ADC_HELP_MSG = (
 # The access token along with the seconds in which it expires.
 AccessTokenInfo = collections.namedtuple(
     'AccessTokenInfo', ['access_token', 'expires_in'])
+
+DEFAULT_ENV_NAME = 'UNKNOWN'
+SETTINGS = collections.namedtuple(
+  'Settings', ['env_name'])(env_name=None)
 
 
 class Error(Exception):
@@ -938,24 +941,24 @@ def _get_environment(urlopen=None):
       urlopen: Optional argument. Function used to open a connection to a URL.
 
   Returns:
-      The value of client_settings.ENV_NAME after being set. If already
+      The value of SETTINGS.env_name after being set. If already
           set, simply returns the value.
   """
-  if client_settings.ENV_NAME is not None:
-    return client_settings.ENV_NAME
+  if SETTINGS.env_name is not None:
+    return SETTINGS.env_name
 
   # None is an unset value, not the default.
-  client_settings.ENV_NAME = client_settings.DEFAULT_ENV
+  SETTINGS.env_name = DEFAULT_ENV_NAME
 
   server_software = os.environ.get('SERVER_SOFTWARE', '')
   if server_software.startswith('Google App Engine/'):
-    client_settings.ENV_NAME = 'GAE_PRODUCTION'
+    SETTINGS.env_name = 'GAE_PRODUCTION'
   elif server_software.startswith('Development/'):
-    client_settings.ENV_NAME = 'GAE_LOCAL'
+    SETTINGS.env_name = 'GAE_LOCAL'
   elif _detect_gce_environment(urlopen=urlopen):
-    client_settings.ENV_NAME = 'GCE_PRODUCTION'
+    SETTINGS.env_name = 'GCE_PRODUCTION'
 
-  return client_settings.ENV_NAME
+  return SETTINGS.env_name
 
 
 class GoogleCredentials(OAuth2Credentials):

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -33,6 +33,7 @@ from six.moves import urllib
 
 import httplib2
 from oauth2client import clientsecrets
+from oauth2client import client_settings
 from oauth2client import GOOGLE_AUTH_URI
 from oauth2client import GOOGLE_DEVICE_URI
 from oauth2client import GOOGLE_REVOKE_URI
@@ -910,35 +911,51 @@ class AccessTokenCredentials(OAuth2Credentials):
     self._do_revoke(http_request, self.access_token)
 
 
-_env_name = None
+def _detect_gce_environment(urlopen=None):
+  """Determine if the current environment is Compute Engine.
+
+  Args:
+      urlopen: Optional argument. Function used to open a connection to a URL.
+
+  Returns:
+      Boolean indicating whether or not the current environment is Google
+          Compute Engine.
+  """
+  urlopen = urlopen or urllib.request.urlopen
+
+  try:
+    response = urlopen('http://metadata.google.internal')
+    return any('Metadata-Flavor: Google' in header
+               for header in response.info().headers)
+  except urllib.error.URLError:
+    return False
 
 
 def _get_environment(urlopen=None):
-  """Detect the environment the code is being run on."""
+  """Detect the environment the code is being run on.
 
-  global _env_name
+  Args:
+      urlopen: Optional argument. Function used to open a connection to a URL.
 
-  if _env_name:
-    return _env_name
+  Returns:
+      The value of client_settings.ENV_NAME after being set. If already
+          set, simply returns the value.
+  """
+  if client_settings.ENV_NAME is not None:
+    return client_settings.ENV_NAME
+
+  # None is an unset value, not the default.
+  client_settings.ENV_NAME = client_settings.DEFAULT_ENV
 
   server_software = os.environ.get('SERVER_SOFTWARE', '')
   if server_software.startswith('Google App Engine/'):
-    _env_name = 'GAE_PRODUCTION'
+    client_settings.ENV_NAME = 'GAE_PRODUCTION'
   elif server_software.startswith('Development/'):
-    _env_name = 'GAE_LOCAL'
-  else:
-    try:
-      if urlopen is None:
-        urlopen = urllib.request.urlopen
-      response = urlopen('http://metadata.google.internal')
-      if any('Metadata-Flavor: Google' in h for h in response.info().headers):
-        _env_name = 'GCE_PRODUCTION'
-      else:
-        _env_name = 'UNKNOWN'
-    except urllib.error.URLError:
-      _env_name = 'UNKNOWN'
+    client_settings.ENV_NAME = 'GAE_LOCAL'
+  elif _detect_gce_environment(urlopen=urlopen):
+    client_settings.ENV_NAME = 'GCE_PRODUCTION'
 
-  return _env_name
+  return client_settings.ENV_NAME
 
 
 class GoogleCredentials(OAuth2Credentials):
@@ -952,37 +969,19 @@ class GoogleCredentials(OAuth2Credentials):
   Here is an example of how to use the Application Default Credentials for a
   service that requires authentication:
 
-  <code>
-  from __future__ import print_function  # unnecessary in python3
-  from googleapiclient.discovery import build
-  from oauth2client.client import GoogleCredentials
+      from googleapiclient.discovery import build
+      from oauth2client.client import GoogleCredentials
 
-  PROJECT = 'bamboo-machine-422'  # replace this with one of your projects
-  ZONE = 'us-central1-a'          # replace this with the zone you care about
+      credentials = GoogleCredentials.get_application_default()
+      service = build('compute', 'v1', credentials=credentials)
 
-  credentials = GoogleCredentials.get_application_default()
-  service = build('compute', 'v1', credentials=credentials)
+      PROJECT = 'bamboo-machine-422'
+      ZONE = 'us-central1-a'
+      request = service.instances().list(project=PROJECT, zone=ZONE)
+      response = request.execute()
 
-  request = service.instances().list(project=PROJECT, zone=ZONE)
-  response = request.execute()
-
-  print(response)
-  </code>
-
-  A service that does not require authentication does not need credentials
-  to be passed in:
-
-  <code>
-  from googleapiclient.discovery import build
-
-  service = build('discovery', 'v1')
-
-  request = service.apis().list()
-  response = request.execute()
-
-  print(response)
-  </code>
-  """
+      print(response)
+ """
 
   def __init__(self, access_token, client_id, client_secret, refresh_token,
                token_expiry, token_uri, user_agent,

--- a/oauth2client/client_settings.py
+++ b/oauth2client/client_settings.py
@@ -1,0 +1,2 @@
+ENV_NAME = None
+DEFAULT_ENV = 'UNKNOWN'

--- a/oauth2client/client_settings.py
+++ b/oauth2client/client_settings.py
@@ -1,2 +1,0 @@
-ENV_NAME = None
-DEFAULT_ENV = 'UNKNOWN'

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -60,7 +60,6 @@ from oauth2client.client import SERVICE_ACCOUNT
 from oauth2client.client import Storage
 from oauth2client.client import TokenRevokeError
 from oauth2client.client import VerifyJwtTokenError
-from oauth2client.client import _env_name
 from oauth2client.client import _extract_id_token
 from oauth2client.client import _get_application_default_credential_from_file
 from oauth2client.client import _get_environment
@@ -73,6 +72,7 @@ from oauth2client.client import credentials_from_clientsecrets_and_code
 from oauth2client.client import credentials_from_code
 from oauth2client.client import flow_from_clientsecrets
 from oauth2client.client import save_to_well_known_file
+from oauth2client import client_settings
 from oauth2client.clientsecrets import _loadfile
 from oauth2client.service_account import _ServiceAccountCredentials
 
@@ -151,7 +151,7 @@ class GoogleCredentialsTests(unittest.TestCase):
     self.env_appdata = os.environ.get('APPDATA', None)
     self.os_name = os.name
     from oauth2client import client
-    setattr(client, '_env_name', None)
+    client_settings.ENV_NAME = None
 
   def tearDown(self):
     self.reset_env('SERVER_SOFTWARE', self.env_server_software)
@@ -234,7 +234,8 @@ class GoogleCredentialsTests(unittest.TestCase):
 
     m.ReplayAll()
 
-    self.assertEqual('UNKNOWN', _get_environment(urllib2_urlopen))
+    self.assertEqual(client_settings.DEFAULT_ENV,
+                     _get_environment(urllib2_urlopen))
 
     m.UnsetStubs()
     m.VerifyAll()
@@ -383,9 +384,9 @@ class GoogleCredentialsTests(unittest.TestCase):
 
   def test_env_name(self):
     from oauth2client import client
-    self.assertEqual(None, getattr(client, '_env_name'))
+    self.assertEqual(None, client_settings.ENV_NAME)
     self.test_get_application_default_from_environment_variable_service_account()
-    self.assertEqual('UNKNOWN', getattr(client, '_env_name'))
+    self.assertEqual(client_settings.DEFAULT_ENV, client_settings.ENV_NAME)
 
   def test_get_application_default_from_environment_variable_authorized_user(
       self):

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -39,6 +39,7 @@ from .http_mock import HttpMock
 from .http_mock import HttpMockSequence
 from oauth2client import GOOGLE_REVOKE_URI
 from oauth2client import GOOGLE_TOKEN_URI
+from oauth2client import client
 from oauth2client.client import AccessTokenCredentials
 from oauth2client.client import AccessTokenCredentialsError
 from oauth2client.client import AccessTokenRefreshError
@@ -46,6 +47,7 @@ from oauth2client.client import ADC_HELP_MSG
 from oauth2client.client import AssertionCredentials
 from oauth2client.client import AUTHORIZED_USER
 from oauth2client.client import Credentials
+from oauth2client.client import DEFAULT_ENV_NAME
 from oauth2client.client import ApplicationDefaultCredentialsError
 from oauth2client.client import FlowExchangeError
 from oauth2client.client import GoogleCredentials
@@ -72,7 +74,6 @@ from oauth2client.client import credentials_from_clientsecrets_and_code
 from oauth2client.client import credentials_from_code
 from oauth2client.client import flow_from_clientsecrets
 from oauth2client.client import save_to_well_known_file
-from oauth2client import client_settings
 from oauth2client.clientsecrets import _loadfile
 from oauth2client.service_account import _ServiceAccountCredentials
 
@@ -151,7 +152,7 @@ class GoogleCredentialsTests(unittest.TestCase):
     self.env_appdata = os.environ.get('APPDATA', None)
     self.os_name = os.name
     from oauth2client import client
-    client_settings.ENV_NAME = None
+    client.SETTINGS.env_name = None
 
   def tearDown(self):
     self.reset_env('SERVER_SOFTWARE', self.env_server_software)
@@ -234,8 +235,7 @@ class GoogleCredentialsTests(unittest.TestCase):
 
     m.ReplayAll()
 
-    self.assertEqual(client_settings.DEFAULT_ENV,
-                     _get_environment(urllib2_urlopen))
+    self.assertEqual(DEFAULT_ENV_NAME, _get_environment(urllib2_urlopen))
 
     m.UnsetStubs()
     m.VerifyAll()
@@ -384,9 +384,9 @@ class GoogleCredentialsTests(unittest.TestCase):
 
   def test_env_name(self):
     from oauth2client import client
-    self.assertEqual(None, client_settings.ENV_NAME)
+    self.assertEqual(None, client.SETTINGS.env_name)
     self.test_get_application_default_from_environment_variable_service_account()
-    self.assertEqual(client_settings.DEFAULT_ENV, client_settings.ENV_NAME)
+    self.assertEqual(DEFAULT_ENV_NAME, client.SETTINGS.env_name)
 
   def test_get_application_default_from_environment_variable_authorized_user(
       self):


### PR DESCRIPTION
- Removes use of "global" by putting the env name in another
  namespace.
- Splits logic into digestible pieces.
- Also makes slight change to GoogleCredentials docstring.

This is the first chunk of #80. I'm happy to wait until #82 is in and rebase.
