### PR TITLE
Re-enable Python3 tests and fixing Py2/Py3 issues in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ env:
   - TOX_ENV=py26openssl14
   - TOX_ENV=py27openssl13
   - TOX_ENV=py27openssl14
+  - TOX_ENV=py33openssl14
+  - TOX_ENV=py34openssl14
   - TOX_ENV=pypyopenssl13
   - TOX_ENV=pypyopenssl14
 install:

--- a/oauth2client/service_account.py
+++ b/oauth2client/service_account.py
@@ -19,6 +19,7 @@ This credentials class is implemented on top of rsa library.
 
 import base64
 import json
+import six
 import time
 
 from pyasn1.codec.ber import decoder
@@ -131,6 +132,8 @@ def _urlsafe_b64encode(data):
 def _get_private_key(private_key_pkcs8_text):
   """Get an RSA private key object from a pkcs8 representation."""
 
+  if not isinstance(private_key_pkcs8_text, six.binary_type):
+    private_key_pkcs8_text = private_key_pkcs8_text.encode('ascii')
   der = rsa.pem.load_pem(private_key_pkcs8_text, 'PRIVATE KEY')
   asn1_private_key, _ = decoder.decode(der, asn1Spec=PrivateKeyInfo())
   return rsa.PrivateKey.load_pkcs1(

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -217,7 +217,7 @@ class SignedJwtAssertionCredentialsTests(unittest.TestCase):
     ])
     http = credentials.authorize(http)
     resp, content = http.request('http://example.org')
-    self.assertEqual('Bearer 1/3w', content['Authorization'])
+    self.assertEqual(b'Bearer 1/3w', content[b'Authorization'])
 
   def test_credentials_to_from_json(self):
     private_key = datafile('privatekey.%s' % self.format)
@@ -254,7 +254,7 @@ class SignedJwtAssertionCredentialsTests(unittest.TestCase):
 
     content = self._credentials_refresh(credentials)
 
-    self.assertEqual('Bearer 3/3w', content['Authorization'])
+    self.assertEqual(b'Bearer 3/3w', content[b'Authorization'])
 
   def test_credentials_refresh_with_storage(self):
     private_key = datafile('privatekey.%s' % self.format)
@@ -272,7 +272,7 @@ class SignedJwtAssertionCredentialsTests(unittest.TestCase):
 
     content = self._credentials_refresh(credentials)
 
-    self.assertEqual('Bearer 3/3w', content['Authorization'])
+    self.assertEqual(b'Bearer 3/3w', content[b'Authorization'])
     os.unlink(filename)
 
 


### PR DESCRIPTION
Partially fixes #85.

Still need to re-enable the 5 tests which make HTTP requests.
