### PR TITLE
Fix an encoding issue, add a test.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -409,7 +409,9 @@ def clean_headers(headers):
   clean = {}
   try:
     for k, v in six.iteritems(headers):
-      clean[k.encode('ascii')] = v.encode('ascii')
+      clean_k = k if isinstance(k, bytes) else str(k).encode('ascii')
+      clean_v = v if isinstance(v, bytes) else str(v).encode('ascii')
+      clean[clean_k] = clean_v
   except UnicodeEncodeError:
     raise NonAsciiHeaderError(k + ': ' + v)
   return clean


### PR DESCRIPTION
PTAL @dhermes -- this seems like a good fix, though honestly i think maybe the original `str(k)` and `str(v)` works fine (from my experimenting with httplib/httplib2 in py2 and py3).
