### PR TITLE
Clean up test envs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: python
 python: 2.7
 env:
-  - TOX_ENV=py26openssl13
-  - TOX_ENV=py26openssl14
-  - TOX_ENV=py27openssl13
-  - TOX_ENV=py27openssl14
-  - TOX_ENV=py33openssl14
-  - TOX_ENV=py34openssl14
-  - TOX_ENV=pypyopenssl13
-  - TOX_ENV=pypyopenssl14
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+  - TOX_ENV=py33
+  - TOX_ENV=py34
+  - TOX_ENV=pypy
 install:
   - pip install tox
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,15 @@
 [tox]
-envlist = py26openssl13, py26openssl14,
-          py27openssl13, py27openssl14,
-                         py33openssl14,
-                         py34openssl14,
-          pypyopenssl13, pypyopenssl14,
-          cover
+envlist = py26,py27,py33,py34,pypy,cover
 
 [testenv]
-deps = keyring
-       mox3
-       pycrypto==2.6
-       django>=1.5,<1.6
-       webtest
-       nose
+basedeps = keyring
+           mox3
+           pycrypto==2.6
+           django>=1.5,<1.6
+           webtest
+           nose
+deps = {[testenv]basedeps}
+       pyopenssl==0.14
 setenv = PYTHONPATH=../google_appengine
 commands = nosetests --ignore-files=test_appengine\.py
 
@@ -22,54 +19,13 @@ branches:
     - master
     - python3
 
-[testenv:py26openssl13]
-basepython = python2.6
-deps = {[testenv]deps}
-    pyopenssl<0.14
-
-[testenv:py26openssl14]
-basepython = python2.6
-deps = {[testenv]deps}
-    pyopenssl==0.14
-
-[testenv:py27openssl13]
-basepython = python2.7
-deps = {[testenv]deps}
-    pyopenssl<0.14
-
-[testenv:py27openssl14]
-basepython = python2.7
-deps = {[testenv]deps}
-    pyopenssl==0.14
-
-[testenv:py33openssl14]
-basepython = python3.3
-deps = {[testenv]deps}
-    pyopenssl==0.14
-
-[testenv:py34openssl14]
-basepython = python3.4
-deps = {[testenv]deps}
-    pyopenssl==0.14
-
-[testenv:pypyopenssl13]
-deps = {[testenv]deps}
-    pyopenssl<0.14
-
-[testenv:pypyopenssl14]
-deps = {[testenv]deps}
-    pyopenssl==0.14
-
 [testenv:cover]
-basepython =
-    python2.7
+basepython = python2.7
 commands =
     nosetests --with-xunit --with-xcoverage --cover-package=oauth2client --nocapture --cover-erase --cover-tests --cover-branches --ignore-files=test_appengine\.py --cover-min-percentage=60
 deps = {[testenv]deps}
-    coverage>=3.6,<3.99
+    coverage
     nosexcover
-    rsa
-    pyopenssl==0.14
 
 [testenv:coveralls]
 basepython = {[testenv:cover]basepython}
@@ -79,3 +35,13 @@ commands =
 deps =
     {[testenv:cover]deps}
     coveralls
+
+[testenv:py26openssl13]
+basepython = python2.6
+deps = {[testenv]basedeps}
+    pyopenssl<0.14
+
+[testenv:py27openssl13]
+basepython = python2.7
+deps = {[testenv]basedeps}
+    pyopenssl<0.14


### PR DESCRIPTION
We have a number of extra envs due to checking two versions of pyopenssl (0.13
and 0.14); this isn't actually necessary, since 0.14 is the one we really care
about for the external repo.

This cleans up the cases and names (and drastically shortens `tox.ini`), but
keeps the old envs available for manual testing.

PTAL @dhermes (why does github fail to autocomplete your name?)
