### PR TITLE
Avoid converting to bytes the Python 3 str header values

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -410,12 +410,8 @@ def clean_headers(headers):
   clean = {}
   try:
     for k, v in six.iteritems(headers):
-      if six.PY3:
-        clean_k = str(k)
-        clean_v = str(v)
-      else:
-        clean_k = k if isinstance(k, bytes) else str(k).encode('ascii')
-        clean_v = v if isinstance(v, bytes) else str(v).encode('ascii')
+      clean_k = k if isinstance(k, bytes) else str(k).encode('ascii')
+      clean_v = v if isinstance(v, bytes) else str(v).encode('ascii')
       clean[clean_k] = clean_v
   except UnicodeEncodeError:
     raise NonAsciiHeaderError(k + ': ' + v)

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -410,8 +410,12 @@ def clean_headers(headers):
   clean = {}
   try:
     for k, v in six.iteritems(headers):
-      clean_k = k if isinstance(k, bytes) else str(k).encode('ascii')
-      clean_v = v if isinstance(v, bytes) else str(v).encode('ascii')
+      if six.PY3:
+        clean_k = str(k)
+        clean_v = str(v)
+      else:
+        clean_k = k if isinstance(k, bytes) else str(k).encode('ascii')
+        clean_v = v if isinstance(v, bytes) else str(v).encode('ascii')
       clean[clean_k] = clean_v
   except UnicodeEncodeError:
     raise NonAsciiHeaderError(k + ': ' + v)

--- a/tests/http_mock.py
+++ b/tests/http_mock.py
@@ -55,7 +55,14 @@ class HttpMock(object):
     self.uri = uri
     self.method = method
     self.body = body
+
+    # NB: reproduce the header normalization behavior
+    if headers is None:
+      headers = {}
+    else:
+      headers = httplib2._normalize_headers(headers)
     self.headers = headers
+
     return httplib2.Response(self.response_headers), self.data
 
 


### PR DESCRIPTION
the method `clean_headers` was turning python 3 str instances into bytes, which was causing the httplib2 module to raise an exception.

Cheers
