### PR TITLE
Explicitly fail for python3 versions < 3.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,6 @@ To install, simply say
 
     $ pip install --upgrade oauth2client
 
-
-Third Party Libraries
-=====================
-
-These libraries will be installed when you install the client library:
-
-* https://github.com/jcgregorio/httplib2
-
 Contributing
 ============
 
@@ -28,3 +20,9 @@ Please see the
 [contributing page](http://google.github.io/oauth2client/contributing.html)
 for more information. In particular, we love pull requests -- but please make
 sure to sign the contributor license agreement.
+
+Supported Python Versions
+=========================
+
+We support Python 2.6, 2.7, 3.3+. More information
+[in the docs](http://google.github.io/oauth2client/#supported-python-versions).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,3 +50,22 @@ contributor license agreement.
 
    source/modules
    contributing
+
+Supported Python Versions
+-------------------------
+
+We support Python 2.6, 2.7, 3.3+. (Whatever this file says, the truth is
+always represented by our `tox.ini`_).
+
+.. _tox.ini: https://github.com/google/oauth2client/blob/master/tox.ini
+
+We explicitly decided to support Python 3 beginning with version
+3.3. Reasons for this include:
+
+* Encouraging use of newest versions of Python 3
+* Following the lead of prominent `open-source projects`_
+* Unicode literal support which
+  allows for a cleaner codebase that works in both Python 2 and Python 3
+
+.. _open-source projects: http://docs.python-requests.org/en/latest/
+.. _Unicode literal support: https://www.python.org/dev/peps/pep-0414/

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,11 @@ from __future__ import print_function
 
 import sys
 
-if sys.version_info <= (2, 6):
-  print('oauth2client requires python version >= 2.6.', file=sys.stderr)
+if sys.version_info < (2, 6):
+  print('oauth2client requires python2 version >= 2.6.', file=sys.stderr)
+  sys.exit(1)
+if (3, 1) <= sys.version_info < (3, 3):
+  print('oauth2client requires python3 version >= 3.3.', file=sys.stderr)
   sys.exit(1)
 
 from setuptools import setup


### PR DESCRIPTION
we just need to add a check in `setup.py`.
