### PR TITLE
Modify invalid format exception error to give more context 

### DIFF
--- a/oauth2client/clientsecrets.py
+++ b/oauth2client/clientsecrets.py
@@ -69,8 +69,18 @@ class InvalidClientSecretsError(Error):
 
 
 def _validate_clientsecrets(obj):
-  if obj is None or len(obj) != 1:
-    raise InvalidClientSecretsError('Invalid file format.')
+  _INVALID_FILE_FORMAT_MSG = (
+    'Invalid file format. See '
+    'https://developers.google.com/api-client-library/'
+    'python/guide/aaa_client_secrets')
+
+  if obj is None:
+    raise InvalidClientSecretsError(_INVALID_FILE_FORMAT_MSG)
+  if len(obj) != 1:
+    raise InvalidClientSecretsError(
+      _INVALID_FILE_FORMAT_MSG + ' '
+      'Expected a JSON object with a single property for a "web" or '
+      '"installed" application')
   client_type = tuple(obj)[0]
   if client_type not in VALID_CLIENT:
     raise InvalidClientSecretsError('Unknown client type: %s.' % (client_type,))


### PR DESCRIPTION
Modify invalid exception error to be less cryptic and give more context to the developer.

This is to fix my personal debugging experience when
trying to debug the fact that I had downloaded the
wrong client secret JSON type (not web/installed).
