### PR TITLE
Update type on run_flow() to be accurate

### DIFF
--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -147,7 +147,9 @@ def run_flow(flow, storage, flags, http=None):
   Args:
     flow: Flow, an OAuth 2.0 Flow to step through.
     storage: Storage, a Storage to store the credential in.
-    flags: argparse.ArgumentParser, the command-line flags.
+    flags: argparse.Namespace, The command-line flags. This is the object
+        returned from calling parse_args() on
+        argparse.ArgumentParser as described above.
     http: An instance of httplib2.Http.request
          or something that acts like it.
 


### PR DESCRIPTION
Fix comment on run_flow() -- flags is not an ArgumentParser, it is a Namespace, the result of calling parse_args() on an ArgumentParser object. This was a source of confusion when using the api.
