### PR TITLE
Use six to call raw_input for Python 3 support

### DIFF
--- a/oauth2client/old_run.py
+++ b/oauth2client/old_run.py
@@ -23,6 +23,7 @@ import sys
 import webbrowser
 
 import gflags
+from six.moves import input
 
 from oauth2client import client
 from oauth2client import util
@@ -147,7 +148,7 @@ def run(flow, storage, http=None):
       print('Failed to find "code" in the query parameters of the redirect.')
       sys.exit('Try running with --noauth_local_webserver.')
   else:
-    code = raw_input('Enter verification code: ').strip()
+    code = input('Enter verification code: ').strip()
 
   try:
     credential = flow.step2_exchange(code, http=http)

--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -30,6 +30,7 @@ import sys
 
 from six.moves import BaseHTTPServer
 from six.moves import urllib
+from six.moves import input
 
 from oauth2client import client
 from oauth2client import util
@@ -216,7 +217,7 @@ def run_flow(flow, storage, flags, http=None):
       print('Failed to find "code" in the query parameters of the redirect.')
       sys.exit('Try running with --noauth_local_webserver.')
   else:
-    code = raw_input('Enter verification code: ').strip()
+    code = input('Enter verification code: ').strip()
 
   try:
     credential = flow.step2_exchange(code, http=http)

--- a/samples/oauth2_for_devices.py
+++ b/samples/oauth2_for_devices.py
@@ -3,6 +3,7 @@
 # See:  https://developers.google.com/accounts/docs/OAuth2ForDevices
 
 import httplib2
+from six.moves import input
 from oauth2client.client import OAuth2WebServerFlow
 from googleapiclient.discovery import build
 
@@ -18,7 +19,7 @@ flow_info = flow.step1_get_device_and_user_codes()
 print "Enter the following code at %s: %s" % (flow_info.verification_url,
                                               flow_info.user_code)
 print "Then press Enter."
-raw_input()
+input()
 
 # Step 2: get credentials
 # https://developers.google.com/accounts/docs/OAuth2ForDevices#obtainingatoken


### PR DESCRIPTION
In Python 3 `raw_input` was renamed to `input`. Start to use the
compatibility library to call the function.

https://pythonhosted.org/six/#module-six.moves
