### PR TITLE
Added b prefix for string used in BaseHTTPRequestHandler wfile.write

### DIFF
--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -99,9 +99,9 @@ class ClientRedirectHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     query = self.path.split('?', 1)[-1]
     query = dict(urllib.parse.parse_qsl(query))
     self.server.query_params = query
-    self.wfile.write("<html><head><title>Authentication Status</title></head>")
-    self.wfile.write("<body><p>The authentication flow has completed.</p>")
-    self.wfile.write("</body></html>")
+    self.wfile.write(b"<html><head><title>Authentication Status</title></head>")
+    self.wfile.write(b"<body><p>The authentication flow has completed.</p>")
+    self.wfile.write(b"</body></html>")
 
   def log_message(self, format, *args):
     """Do not log messages to stdout while running as command line program."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,30 @@
+"""Unit tests for oauth2client.tools."""
+
+import unittest
+from oauth2client import tools
+from six.moves.urllib import request
+import threading
+
+class TestClientRedirectServer(unittest.TestCase):
+    """Test the ClientRedirectServer and ClientRedirectHandler classes."""
+
+    def test_ClientRedirectServer(self):
+        # create a ClientRedirectServer and run it in a thread to listen
+        # for a mock GET request with the access token
+        # the server should return a 200 message and store the token
+        httpd = tools.ClientRedirectServer(('localhost', 0), tools.ClientRedirectHandler)
+        code = 'foo'
+        url = 'http://localhost:%i?code=%s' % (httpd.server_address[1], code)
+        t = threading.Thread(target = httpd.handle_request)
+        t.setDaemon(True)
+        t.start()
+        f = request.urlopen( url )
+        self.assertTrue(f.read())
+        t.join()
+        httpd.server_close()
+        self.assertEqual(httpd.query_params.get('code'),code)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
In Python 3 the BaseHTTPRequestHandler need bytes streams to write to the output, with simple strings the following exception occurs:

```
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 43494)
Traceback (most recent call last):
  File "/usr/lib/python3.4/socketserver.py", line 305, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python3.4/socketserver.py", line 331, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python3.4/socketserver.py", line 344, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.4/socketserver.py", line 665, in __init__
    self.handle()
  File "/usr/lib/python3.4/http/server.py", line 398, in handle
    self.handle_one_request()
  File "/usr/lib/python3.4/http/server.py", line 386, in handle_one_request
    method()
  File "/usr/local/lib/python3.4/dist-packages/oauth2client/tools.py", line 101, in do_GET
    self.wfile.write("<html><head><title>Authentication Status</title></head>")
  File "/usr/lib/python3.4/socket.py", line 391, in write
    return self._sock.send(b)
TypeError: 'str' does not support the buffer interface
----------------------------------------
```

Using b"" prefix for these strings is safe because the response is plain ASCII and it will also be compatible with Python 2.6 and 2.7
