### PR TITLE
Fix example to be Python3 compatible, use format()

### DIFF
--- a/samples/oauth2_for_devices.py
+++ b/samples/oauth2_for_devices.py
@@ -16,16 +16,16 @@ flow = OAuth2WebServerFlow(CLIENT_ID, CLIENT_SECRET, " ".join(SCOPES))
 # Step 1: get user code and verification URL
 # https://developers.google.com/accounts/docs/OAuth2ForDevices#obtainingacode
 flow_info = flow.step1_get_device_and_user_codes()
-print "Enter the following code at %s: %s" % (flow_info.verification_url,
-                                              flow_info.user_code)
-print "Then press Enter."
+print("Enter the following code at {0}: {1}".format(flow_info.verification_url,
+                                                    flow_info.user_code))
+print("Then press Enter.")
 input()
 
 # Step 2: get credentials
 # https://developers.google.com/accounts/docs/OAuth2ForDevices#obtainingatoken
 credentials = flow.step2_exchange(device_flow_info=flow_info)
-print "Access token:", credentials.access_token
-print "Refresh token:", credentials.refresh_token
+print("Access token:  {0}".format(credentials.access_token))
+print("Refresh token: {0}".format(credentials.refresh_token))
 
 # Get YouTube service
 # https://developers.google.com/accounts/docs/OAuth2ForDevices#callinganapi


### PR DESCRIPTION
Both print() and format() are compatible from 2.6. Also, format() is much nicer to use for internationalization since you can define the location of your substitutions. It works similarly to Java and .net's format() as well. Great stuff!

Should I tackle the other examples as well, or is piece meal all right?
