### PR TITLE
Switched headers to be normalized as strings, not bytes, in keeping with httplib2.

### DIFF
--- a/tests/test_appengine.py
+++ b/tests/test_appengine.py
@@ -29,7 +29,11 @@ import os
 import time
 import unittest
 import urllib
-import urlparse
+
+try:
+  import urlparse
+except ImportError:
+  from urllib.parse import urlparse
 
 import dev_appserver
 dev_appserver.fix_sys_path()

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -220,7 +220,7 @@ class SignedJwtAssertionCredentialsTests(unittest.TestCase):
     ])
     http = credentials.authorize(http)
     resp, content = http.request('http://example.org')
-    self.assertEqual(b'Bearer 1/3w', content[b'Authorization'])
+    self.assertEqual('Bearer 1/3w', content['Authorization'])
 
   def test_credentials_to_from_json(self):
     private_key = datafile('privatekey.%s' % self.format)
@@ -257,7 +257,7 @@ class SignedJwtAssertionCredentialsTests(unittest.TestCase):
 
     content = self._credentials_refresh(credentials)
 
-    self.assertEqual(b'Bearer 3/3w', content[b'Authorization'])
+    self.assertEqual('Bearer 3/3w', content['Authorization'])
 
   def test_credentials_refresh_with_storage(self):
     private_key = datafile('privatekey.%s' % self.format)
@@ -275,7 +275,7 @@ class SignedJwtAssertionCredentialsTests(unittest.TestCase):
 
     content = self._credentials_refresh(credentials)
 
-    self.assertEqual(b'Bearer 3/3w', content[b'Authorization'])
+    self.assertEqual('Bearer 3/3w', content['Authorization'])
     os.unlink(filename)
 
 


### PR DESCRIPTION
It appears that earlier contributors made the attempt to keep everything as bytes, mostly deducing from the test code. This doesn't work with the Python3 version of `httplib2`, and it is exactly this issue (`bytes` being passed to the Python3 version of `httplib2` instead of `str`) that causes [corrupt headers](https://github.com/GoogleCloudPlatform/gcloud-python/issues/653).  `httplib2` is [very clear](https://github.com/jcgregorio/httplib2/blob/df1cca48b204fc20fde1e49d7ad763394b01d931/python3/README#L8-L11) about [what it expects](https://github.com/jcgregorio/httplib2/wiki/Examples-Python3).

Given the dependency on `httplib2`, in `oauth2client`, it makes sense to me that `oauth2client` should follow its lead and use whatever version of `str` for headers makes sense in the version of Python it is using.
- Fixed header strings to use strings and not bytes.
- Fixed tests to work with Python3
