### PR TITLE
Using fake ~/.config/gcloud directory for failing defaults test.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -76,6 +76,9 @@ SERVICE_ACCOUNT = 'service_account'
 # The environment variable pointing the file with local
 # Application Default Credentials.
 GOOGLE_APPLICATION_CREDENTIALS = 'GOOGLE_APPLICATION_CREDENTIALS'
+# The ~/.config subdirectory containing gcloud credentials. Intended
+# to be swapped out in tests.
+_CLOUDSDK_CONFIG_DIRECTORY = 'gcloud'
 
 # The error message we show users when we can't find the Application
 # Default Credentials.
@@ -1249,20 +1252,20 @@ def _get_well_known_file():
   # of pinpointing the exact location of the file.
 
   WELL_KNOWN_CREDENTIALS_FILE = 'application_default_credentials.json'
-  CLOUDSDK_CONFIG_DIRECTORY = 'gcloud'
 
   if os.name == 'nt':
     try:
       default_config_path = os.path.join(os.environ['APPDATA'],
-                                         CLOUDSDK_CONFIG_DIRECTORY)
+                                         _CLOUDSDK_CONFIG_DIRECTORY)
     except KeyError:
       # This should never happen unless someone is really messing with things.
       drive = os.environ.get('SystemDrive', 'C:')
-      default_config_path = os.path.join(drive, '\\', CLOUDSDK_CONFIG_DIRECTORY)
+      default_config_path = os.path.join(drive, '\\',
+                                         _CLOUDSDK_CONFIG_DIRECTORY)
   else:
     default_config_path = os.path.join(os.path.expanduser('~'),
                                        '.config',
-                                       CLOUDSDK_CONFIG_DIRECTORY)
+                                       _CLOUDSDK_CONFIG_DIRECTORY)
 
   default_config_path = os.path.join(default_config_path,
                                      WELL_KNOWN_CREDENTIALS_FILE)

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -409,11 +409,15 @@ class GoogleCredentialsTests(unittest.TestCase):
     os.environ[GOOGLE_APPLICATION_CREDENTIALS] = ''
     os.environ['APPDATA'] = ''
     # we can't use self.assertRaisesRegexp() because it is only in Python 2.7+
+    VALID_CONFIG_DIR = client._CLOUDSDK_CONFIG_DIRECTORY
     try:
+      client._CLOUDSDK_CONFIG_DIRECTORY = 'BOGUS_CONFIG_DIR'
       GoogleCredentials.get_application_default()
       self.fail('An exception was expected!')
     except ApplicationDefaultCredentialsError as error:
       self.assertEqual(ADC_HELP_MSG, str(error))
+    finally:
+      client._CLOUDSDK_CONFIG_DIRECTORY = VALID_CONFIG_DIR
 
   def test_from_stream_service_account(self):
     credentials_file = datafile(


### PR DESCRIPTION
- Partially fixes #123.
- Still doesn't address the case of running in GAE (unlikely) or
  GCE (fairly likely). Could also address these by mocking the
  environment detectors.
