### PR TITLE
utf-8 decode bytes inputs for python3 compat + python3 test fix

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -272,7 +272,7 @@ class Credentials(object):
       An instance of the subclass of Credentials that was serialized with
       to_json().
     """
-    if six.PY3 and isinstance(s, bytes):
+    if isinstance(s, bytes):
       s = s.decode('utf-8')
     data = json.loads(s)
     # Find and call the right classmethod from_json() to restore the object.
@@ -612,7 +612,7 @@ class OAuth2Credentials(Credentials):
     Returns:
       An instance of a Credentials subclass.
     """
-    if six.PY3 and isinstance(s, bytes):
+    if isinstance(s, bytes):
       s = s.decode('utf-8')
     data = json.loads(s)
     if (data.get('token_expiry') and
@@ -780,7 +780,7 @@ class OAuth2Credentials(Credentials):
     logger.info('Refreshing access_token')
     resp, content = http_request(
         self.token_uri, method='POST', body=body, headers=headers)
-    if six.PY3 and isinstance(content, bytes):
+    if isinstance(content, bytes):
       content = content.decode('utf-8')
     if resp.status == 200:
       d = json.loads(content)
@@ -840,6 +840,8 @@ class OAuth2Credentials(Credentials):
     query_params = {'token': token}
     token_revoke_uri = _update_query_params(self.revoke_uri, query_params)
     resp, content = http_request(token_revoke_uri)
+    if isinstance(content, bytes):
+      content = content.decode('utf-8')
     if resp.status == 200:
       self.invalid = True
     else:
@@ -907,7 +909,7 @@ class AccessTokenCredentials(OAuth2Credentials):
 
   @classmethod
   def from_json(cls, s):
-    if six.PY3 and isinstance(s, bytes):
+    if isinstance(s, bytes):
       s = s.decode('utf-8')
     data = json.loads(s)
     retval = AccessTokenCredentials(
@@ -1494,6 +1496,8 @@ class SignedJwtAssertionCredentials(AssertionCredentials):
 
   @classmethod
   def from_json(cls, s):
+    if isinstance(s, bytes):
+      s = s.decode('utf-8')
     data = json.loads(s)
     retval = SignedJwtAssertionCredentials(
         data['service_account_name'],
@@ -1558,8 +1562,10 @@ def verify_id_token(id_token, audience, http=None,
 
   resp, content = http.request(cert_uri)
 
+  if isinstance(content, bytes):
+    content = content.decode('utf-8')
   if resp.status == 200:
-    certs = json.loads(content.decode('utf-8'))
+    certs = json.loads(content)
     return crypt.verify_signed_jwt_with_certs(id_token, certs, audience)
   else:
     raise VerifyJwtTokenError('Status code: %d' % resp.status)
@@ -1610,12 +1616,13 @@ def _parse_exchange_token_response(content):
     i.e. {}. That basically indicates a failure.
   """
   resp = {}
+  if isinstance(content, bytes):
+    content = content.decode('utf-8')
   try:
-    resp = json.loads(content.decode('utf-8'))
+    resp = json.loads(content)
   except Exception:
     # different JSON libs raise different exceptions,
     # so we just do a catch-all here
-    content = content.decode('utf-8')
     resp = dict(urllib.parse.parse_qsl(content))
 
   # some providers respond with 'expires', others with 'expires_in'
@@ -1871,6 +1878,8 @@ class OAuth2WebServerFlow(Flow):
 
     resp, content = http.request(self.device_uri, method='POST', body=body,
                                  headers=headers)
+    if isinstance(content, bytes):
+      content = content.decode('utf-8')
     if resp.status == 200:
       try:
         flow_info = json.loads(content)

--- a/oauth2client/crypt.py
+++ b/oauth2client/crypt.py
@@ -381,7 +381,9 @@ def verify_signed_jwt_with_certs(jwt, certs, audience):
   # Parse token.
   json_body = _urlsafe_b64decode(segments[1])
   try:
-    parsed = json.loads(json_body.decode('utf-8'))
+    if isinstance(json_body, bytes):
+      json_body = json_body.decode('utf-8')
+    parsed = json.loads(json_body)
   except:
     raise AppIdentityError('Can\'t parse token: %s' % json_body)
 

--- a/oauth2client/gce.py
+++ b/oauth2client/gce.py
@@ -63,6 +63,8 @@ class AppAssertionCredentials(AssertionCredentials):
 
   @classmethod
   def from_json(cls, json_data):
+    if isinstance(json_data, bytes):
+      json_data = json_data.decode('utf-8')
     data = json.loads(json_data)
     return AppAssertionCredentials(data['scope'])
 
@@ -81,6 +83,8 @@ class AppAssertionCredentials(AssertionCredentials):
     query = '?scope=%s' % urllib.parse.quote(self.scope, '')
     uri = META.replace('{?scope}', query)
     response, content = http_request(uri)
+    if isinstance(content, bytes):
+      content = content.decode('utf-8')
     if response.status == 200:
       try:
         d = json.loads(content)

--- a/oauth2client/service_account.py
+++ b/oauth2client/service_account.py
@@ -19,7 +19,6 @@ This credentials class is implemented on top of rsa library.
 
 import base64
 import json
-import six
 import time
 
 from pyasn1.codec.ber import decoder
@@ -130,7 +129,7 @@ def _urlsafe_b64encode(data):
 def _get_private_key(private_key_pkcs8_text):
   """Get an RSA private key object from a pkcs8 representation."""
 
-  if not isinstance(private_key_pkcs8_text, six.binary_type):
+  if not isinstance(private_key_pkcs8_text, bytes):
     private_key_pkcs8_text = private_key_pkcs8_text.encode('ascii')
   der = rsa.pem.load_pem(private_key_pkcs8_text, 'PRIVATE KEY')
   asn1_private_key, _ = decoder.decode(der, asn1Spec=PrivateKeyInfo())

--- a/tests/test_appengine.py
+++ b/tests/test_appengine.py
@@ -28,8 +28,8 @@ import json
 import os
 import time
 import unittest
-import urllib
-import urlparse
+
+from six.moves import urllib
 
 import dev_appserver
 dev_appserver.fix_sys_path()
@@ -550,7 +550,7 @@ class DecoratorTests(unittest.TestCase):
     self.assertEqual(self.decorator.credentials, None)
     response = self.app.get('http://localhost/foo_path')
     self.assertTrue(response.status.startswith('302'))
-    q = urlparse.parse_qs(response.headers['Location'].split('?', 1)[1])
+    q = urllib.parse.parse_qs(response.headers['Location'].split('?', 1)[1])
     self.assertEqual('http://localhost/oauth2callback', q['redirect_uri'][0])
     self.assertEqual('foo_client_id', q['client_id'][0])
     self.assertEqual('foo_scope bar_scope', q['scope'][0])
@@ -571,10 +571,10 @@ class DecoratorTests(unittest.TestCase):
       self.assertEqual('http://localhost/foo_path', parts[0])
       self.assertEqual(None, self.decorator.credentials)
       if self.decorator._token_response_param:
-        response_query = urlparse.parse_qs(parts[1])
+        response_query = urllib.parse.parse_qs(parts[1])
         response = response_query[self.decorator._token_response_param][0]
         self.assertEqual(Http2Mock.content,
-                         json.loads(urllib.unquote(response)))
+                         json.loads(urllib.parse.unquote(response)))
       self.assertEqual(self.decorator.flow, self.decorator._tls.flow)
       self.assertEqual(self.decorator.credentials,
                        self.decorator._tls.credentials)
@@ -605,7 +605,7 @@ class DecoratorTests(unittest.TestCase):
     # Invalid Credentials should start the OAuth dance again.
     response = self.app.get('/foo_path')
     self.assertTrue(response.status.startswith('302'))
-    q = urlparse.parse_qs(response.headers['Location'].split('?', 1)[1])
+    q = urllib.parse.parse_qs(response.headers['Location'].split('?', 1)[1])
     self.assertEqual('http://localhost/oauth2callback', q['redirect_uri'][0])
 
   def test_storage_delete(self):
@@ -650,7 +650,7 @@ class DecoratorTests(unittest.TestCase):
     self.assertEqual('200 OK', response.status)
     self.assertEqual(False, self.decorator.has_credentials())
     url = self.decorator.authorize_url()
-    q = urlparse.parse_qs(url.split('?', 1)[1])
+    q = urllib.parse.parse_qs(url.split('?', 1)[1])
     self.assertEqual('http://localhost/oauth2callback', q['redirect_uri'][0])
     self.assertEqual('foo_client_id', q['client_id'][0])
     self.assertEqual('foo_scope bar_scope', q['scope'][0])

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -50,6 +50,23 @@ class AssertionCredentialsTests(unittest.TestCase):
         'default/acquire'
         '?scope=http%3A%2F%2Fexample.com%2Fa%20http%3A%2F%2Fexample.com%2Fb')
 
+  def test_good_refresh_bytes(self):
+    http = mock.MagicMock()
+    http.request = mock.MagicMock(
+        return_value=(mock.Mock(status=200),
+                      b'{"accessToken": "this-is-a-token"}'))
+
+    c = AppAssertionCredentials(scope=['http://example.com/a',
+                                       'http://example.com/b'])
+    self.assertEquals(None, c.access_token)
+    c.refresh(http)
+    self.assertEquals('this-is-a-token', c.access_token)
+
+    http.request.assert_called_once_with(
+        'http://metadata.google.internal/0.1/meta-data/service-accounts/'
+        'default/acquire'
+        '?scope=http%3A%2F%2Fexample.com%2Fa%20http%3A%2F%2Fexample.com%2Fb')
+
   def test_fail_refresh(self):
     http = mock.MagicMock()
     http.request = mock.MagicMock(return_value=(mock.Mock(status=400), '{}'))

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -644,8 +644,8 @@ class BasicCredentialsTests(unittest.TestCase):
     http = credentials.authorize(http)
     http.request(u'http://example.com', method=u'GET', headers={u'foo': u'bar'})
     for k, v in six.iteritems(http.headers):
-      self.assertEqual(six.binary_type, type(k))
-      self.assertEqual(six.binary_type, type(v))
+      self.assertEqual(bytes, type(k))
+      self.assertEqual(bytes, type(v))
 
     # Test again with unicode strings that can't simply be converted to ASCII.
     try:


### PR DESCRIPTION
- json loading: always utf-8 decode `bytes` inputs
- tests: use six.moves.urllib for py2/3 compatibility
