### PR TITLE
When refreshing credentials with an stream body, rewind the stream be…

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -554,6 +554,11 @@ class OAuth2Credentials(Credentials):
         else:
           headers['user-agent'] = self.user_agent
 
+      body_stream_position = None
+      if all(getattr(body, stream_prop, None) for stream_prop in
+             ('read', 'seek', 'tell')):
+        body_stream_position = body.tell()
+
       resp, content = request_orig(uri, method, body, clean_headers(headers),
                                    redirections, connection_type)
 
@@ -567,6 +572,9 @@ class OAuth2Credentials(Credentials):
                     refresh_attempt + 1, max_refresh_attempts)
         self._refresh(request_orig)
         self.apply(headers)
+        if body_stream_position is not None:
+          body.seek(body_stream_position)
+
         resp, content = request_orig(uri, method, body, clean_headers(headers),
                                      redirections, connection_type)
 

--- a/tests/http_mock.py
+++ b/tests/http_mock.py
@@ -100,17 +100,16 @@ class HttpMockSequence(object):
               connection_type=None):
     resp, content = self._iterable.pop(0)
     self.requests.append({'uri': uri, 'body': body, 'headers': headers})
+    # Read any underlying stream before sending the request.
+    body_stream_content = body.read() if getattr(body, 'read', None) else None
     if content == 'echo_request_headers':
       content = headers
     elif content == 'echo_request_headers_as_json':
       content = json.dumps(headers)
     elif content == 'echo_request_body':
-      if hasattr(body, 'read'):
-        content = body.read()
-      else:
-        content = body
+      content = body if body_stream_content is None else body_stream_content
     elif content == 'echo_request_uri':
       content = uri
     elif not isinstance(content, bytes):
-      raise TypeError("http content should be bytes: %r" % (content,))
+      raise TypeError('http content should be bytes: %r' % (content,))
     return httplib2.Response(resp), content


### PR DESCRIPTION
…fore re-sending the original request.
