### PR TITLE
Allow the config dir to be missing for read.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1260,6 +1260,10 @@ def save_to_well_known_file(credentials, well_known_file=None):
   if well_known_file is None:
     well_known_file = _get_well_known_file()
 
+  config_dir = os.path.dirname(well_known_file)
+  if not os.path.isdir(config_dir):
+    raise OSError('Config directory does not exist: %s' % config_dir)
+
   credentials_data = credentials.serialization_data
   _save_private_file(well_known_file, credentials_data)
 
@@ -1301,9 +1305,6 @@ def _get_well_known_file():
       default_config_dir = os.path.join(os.path.expanduser('~'),
                                         '.config',
                                         _CLOUDSDK_CONFIG_DIRECTORY)
-
-  if not os.path.isdir(default_config_dir):
-    raise OSError('Config directory does not exist', default_config_dir)
 
   return os.path.join(default_config_dir, WELL_KNOWN_CREDENTIALS_FILE)
 

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -274,14 +274,6 @@ class GoogleCredentialsTests(unittest.TestCase):
       os.environ = ORIGINAL_ENVIRON
       os.path.isdir = ORIGINAL_ISDIR
 
-  def test_get_well_known_file_with_non_existent_config_dir(self):
-    ORIGINAL_ISDIR = os.path.isdir
-    try:
-      os.path.isdir = lambda path: False
-      self.assertRaises(OSError, _get_well_known_file)
-    finally:
-      os.path.isdir = ORIGINAL_ISDIR
-
   def test_get_application_default_credential_from_file_service_account(self):
     credentials_file = datafile(
         os.path.join('gcloud', 'application_default_credentials.json'))
@@ -304,6 +296,18 @@ class GoogleCredentialsTests(unittest.TestCase):
     self.assertEqual('dummy@google.com', d['client_email'])
     self.assertEqual('ABCDEF', d['private_key_id'])
     os.remove(temp_credential_file)
+
+  def test_save_well_known_file_with_non_existent_config_dir(self):
+    credential_file = datafile(
+        os.path.join('gcloud', 'application_default_credentials.json'))
+    credentials = _get_application_default_credential_from_file(
+        credential_file)
+    ORIGINAL_ISDIR = os.path.isdir
+    try:
+      os.path.isdir = lambda path: False
+      self.assertRaises(OSError, save_to_well_known_file, credentials)
+    finally:
+      os.path.isdir = ORIGINAL_ISDIR
 
   def test_get_application_default_credential_from_file_authorized_user(self):
     credentials_file = datafile(


### PR DESCRIPTION
As part of #162, we added a check that the directory containing the well-known
file exists. In the case that we're about to write the file, this nicely
solves the issue raised in #151. However, in the case that we're entirely
indifferent to the existence of the well-known file, this is an overzealous
check.

This PR simply tweaks the code to only fail in the case that the directory
doesn't exist when writing the well-known file.

PTAL @dhermes @anthmgoogle
