### PR TITLE
Simplify OpenSSL checks in crypt.py.

### DIFF
--- a/oauth2client/crypt.py
+++ b/oauth2client/crypt.py
@@ -39,9 +39,7 @@ class AppIdentityError(Exception):
 
 
 try:
-  _, _package_dir, _ = imp.find_module('OpenSSL')
-  if not os.path.isfile(os.path.join(_package_dir, 'crypto.py')):
-    raise ImportError('No module named OpenSSL')
+  _ = imp.find_module('OpenSSL')
 
   class OpenSSLVerifier(object):
     """Verifies the signature on a message."""

--- a/tests/test_crypt.py
+++ b/tests/test_crypt.py
@@ -58,15 +58,17 @@ class Test_pkcs12_key_as_pem(unittest.TestCase):
     self.assertTrue(pem_contents in [pkcs12_key_as_pem, alternate_pem])
 
   def test_without_openssl(self):
-    import os
-    path_isfile = os.path.isfile
+    import imp
+    imp_find_module = imp.find_module
+    def find_module(module_name):
+      raise ImportError('No module named %s' % module_name)
     try:
-      os.path.isfile = lambda value: False
+      imp.find_module = find_module
       reload(crypt)
       self.assertRaises(NotImplementedError, crypt.pkcs12_key_as_pem,
                         'FOO', 'BAR')
     finally:
-      os.path.isfile = path_isfile
+      imp.find_module = imp_find_module
       reload(crypt)
 
   def test_with_nonsense_key(self):


### PR DESCRIPTION
Previously, when confirming OpenSSL is installed, we checked that the module
was installed, and verified that `crypto.py` was contained in the package
directory.

However, this can cause issues in cases of non-standard installs. In addition,
the `imp.find_module` call already raises an `ImportError` in the case that
the module is missing, so this second check isn't needed.

Instead, we just drop the explicit check for `crypto.py` in the `OpenSSL`
directory.

PTAL @dhermes 
