### PR TITLE
Fixing environment detection behavior on GAE Managed VMs.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -992,11 +992,18 @@ def _get_environment(urlopen=None):
   # None is an unset value, not the default.
   SETTINGS.env_name = DEFAULT_ENV_NAME
 
-  server_software = os.environ.get('SERVER_SOFTWARE', '')
-  if server_software.startswith('Google App Engine/'):
-    SETTINGS.env_name = 'GAE_PRODUCTION'
-  elif server_software.startswith('Development/'):
-    SETTINGS.env_name = 'GAE_LOCAL'
+  try:
+    import google.appengine
+    has_gae_sdk = True
+  except ImportError:
+    has_gae_sdk = False
+
+  if has_gae_sdk:
+    server_software = os.environ.get('SERVER_SOFTWARE', '')
+    if server_software.startswith('Google App Engine/'):
+      SETTINGS.env_name = 'GAE_PRODUCTION'
+    elif server_software.startswith('Development/'):
+      SETTINGS.env_name = 'GAE_LOCAL'
   elif NO_GCE_CHECK != 'True' and _detect_gce_environment(urlopen=urlopen):
     SETTINGS.env_name = 'GCE_PRODUCTION'
 


### PR DESCRIPTION
When running on Managed VMs, the evironment variables are set for "SERVER_SOFTWARE" but the user doesn't necessarily have to be using a appengine-compat runtime such as `google/appengine-python`, they could be using a general purpose one such as `google/python-runtime`. Because the generic one doesn't have the app engine sdk, it would crash when trying to obtain default credentials. This fixes the problem by checking if the app engine sdk is importable.
