### PR TITLE
Fixes intermittent EAGAIN failures in devshell tests (#188)

### DIFF
--- a/tests/test_devshell.py
+++ b/tests/test_devshell.py
@@ -44,6 +44,7 @@ class _AuthReferenceServer(threading.Thread):
     port = self._socket.getsockname()[1]
     os.environ[DEVSHELL_ENV] = str(port)
     self._socket.listen(0)
+    self.daemon = True
     self.start()
     return self
 
@@ -57,7 +58,10 @@ class _AuthReferenceServer(threading.Thread):
   def run(self):
     s = None
     try:
-      self._socket.settimeout(15)
+      # Do not set the timeout on the socket, leave it in the blocking mode as
+      # setting the timeout seems to cause spurious EAGAIN errors on OSX.
+      self._socket.settimeout(None)
+
       s, unused_addr = self._socket.accept()
       resp_buffer = ''
       resp_1 = s.recv(6).decode()


### PR DESCRIPTION
Fixes #188 

I was able to reproduce the failure on OSX about every 2nd time before the fix, I could not reproduce it with the fix.  It feels like since settimeout() is handled by Python itself as a deadline on a non-blocking socket, there is some race or something lurking there when the timeout is set.  Haven't looked too deeply though.
