### PR TITLE
Check for OpenSSL.crypto when detecting OpenSSL.

### DIFF
--- a/oauth2client/crypt.py
+++ b/oauth2client/crypt.py
@@ -57,10 +57,14 @@ def _TryOpenSslImport():
 
   """
   try:
-    _ = imp.find_module('OpenSSL')
+    _, _package_dir, _ = imp.find_module('OpenSSL')
+    if not (os.path.isfile(os.path.join(_package_dir, 'crypto.py')) or
+            os.path.isfile(os.path.join(_package_dir, 'crypto.so')) or
+            os.path.isdir(os.path.join(_package_dir, 'crypto'))):
+      raise ImportError('No module named OpenSSL.crypto')
     return
   except ImportError:
-    import OpenSSL
+    import OpenSSL.crypto
 
 
 try:


### PR DESCRIPTION
Previously, we assumed that anyone using `OpenSSL` would have installed it via
a mechanism like `pip`; this has come back to bite us.

We modify our code to look for `OpenSSL.crypto`, not just `OpenSSL`, and add
another (unpleasant) test.

Fixes #190.

PTAL @dhermes 
