### PR TITLE
Remove @util.positional from the authorize() wrapper.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -532,7 +532,6 @@ class OAuth2Credentials(Credentials):
     request_orig = http.request
 
     # The closure that will replace 'httplib2.Http.request'.
-    @util.positional(1)
     def new_request(uri, method='GET', body=None, headers=None,
                     redirections=httplib2.DEFAULT_MAX_REDIRECTS,
                     connection_type=None):


### PR DESCRIPTION
Since the original method does not have a constraint on positional parameters,
its wrapper should not either. See
http://stackoverflow.com/questions/18126157/appengine-warning-during-python-app-update/30469210
for a case where this is producing annoying warnings.
