### PR TITLE
Changing pinned dependencies to >=.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ packages = [
 
 install_requires = [
     'httplib2>=0.9.1',
-    'pyasn1==0.1.7',
+    'pyasn1>=0.1.7',
     'pyasn1_modules>=0.0.5',
-    'rsa==3.1.4',
+    'rsa>=3.1.4',
     'six>=1.6.1',
 ]
 


### PR DESCRIPTION
Fixes #202.

That issue only refers to `pyasn1` but I also resolved the last remaining pinned dependency (`rsa`).
