### PR TITLE
Supports client authentication using Authorization header 

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1828,6 +1828,8 @@ class OAuth2WebServerFlow(Flow):
       **kwargs: dict, The keyword arguments are all optional and required
                         parameters for the OAuth calls.
     """
+    # scope is a required argument, but to preserve backwards-compatibility
+    # we don't want to rearrange the positional arguments
     if scope is None:
       raise TypeError("The value of scope must not be None")
     self.client_id = client_id

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -945,6 +945,9 @@ class OAuth2WebServerFlowTest(unittest.TestCase):
     self.assertEqual(OOB_CALLBACK_URN, q['redirect_uri'][0])
     self.assertEqual('online', q['access_type'][0])
 
+  def test_scope_is_required(self):
+    self.assertRaises(TypeError, OAuth2WebServerFlow, 'client_id+1')
+
   def test_exchange_failure(self):
     http = HttpMockSequence([
       ({'status': '400'}, b'{"error":"invalid_request"}'),

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -1027,6 +1027,29 @@ class OAuth2WebServerFlowTest(unittest.TestCase):
     request_code = urllib.parse.parse_qs(http.requests[0]['body'])['code'][0]
     self.assertEqual(code, request_code)
 
+  def test_exchange_using_authorization_header(self):
+    auth_header = 'Basic Y2xpZW50X2lkKzE6c2VjcmV0KzE=',
+    flow = OAuth2WebServerFlow(
+      client_id='client_id+1',
+      authorization_header=auth_header,
+      scope='foo',
+      redirect_uri=OOB_CALLBACK_URN,
+      user_agent='unittest-sample/1.0',
+      revoke_uri='dummy_revoke_uri',
+        )
+    http = HttpMockSequence([
+      ({'status': '200'}, b'access_token=SlAV32hkKG'),
+    ])
+
+    credentials = flow.step2_exchange('some random code', http=http)
+    self.assertEqual('SlAV32hkKG', credentials.access_token)
+
+    test_request = http.requests[0]
+    # Did we pass the Authorization header?
+    self.assertEqual(test_request['headers']['Authorization'], auth_header)
+    # Did we omit client_secret from POST body?
+    self.assertNotIn('client_secret', test_request['body'])
+
   def test_urlencoded_exchange_success(self):
     http = HttpMockSequence([
       ({'status': '200'}, b'access_token=SlAV32hkKG&expires_in=3600'),


### PR DESCRIPTION
Currently, this client library authenticates by passing `client_id` and `client_secret` in the POST body when exchanging an auth code for an access token.

According to [RFC 6749 section 2.3.1](https://tools.ietf.org/html/rfc6749#section-2.3.1):

>  The authorization server MUST support the HTTP Basic authentication scheme for authenticating clients that were issued a client password.

This changeset adds an optional parameter `authorization_header` to allow use with OAuth2 providers that do not support passing client credentials in the request body.
