### PR TITLE
Automating release via Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,12 @@ after_success:
 - if [[ "${TOX_ENV}" == "py27" ]]; then tox -e coveralls; fi
 notifications:
   email: false
+
+deploy:
+  provider: pypi
+  user: gcloudpypi
+  password:
+    secure: "C9ImNa5kbdnrQNfX9ww4PUtQIr3tN+nfxl7eDkP1B8Qr0QNYjrjov7x+DLImkKvmoJd3dxYtYIpLE9esObUHu0gKHYxqymNHtuAAyoBOUfPtmp0vIEse9brNKMtaey5Ngk7ZWz9EHKBBqRHxqgN+Giby+K9Ta3K3urJIq6urYhE="
+  on:
+    tags: true
+    repo: google/oauth2client


### PR DESCRIPTION
Fixes #213.

@craigcitro or @nathanielmanistaatgoogle we need a real PyPI account for pushing to this repo from Travis or we could just use one of yours and just encrypt it with the Travis command line tool:

```
travis encrypt PW_GOES_HERE
```

/cc @pcostell @eamonnmcmanus 
