### PR TITLE
Import webapp2 instead of google.appengine.ext.webapp

### DIFF
--- a/oauth2client/appengine.py
+++ b/oauth2client/appengine.py
@@ -27,12 +27,12 @@ import pickle
 import threading
 
 import httplib2
+import webapp2 as webapp
 
 from google.appengine.api import app_identity
 from google.appengine.api import memcache
 from google.appengine.api import users
 from google.appengine.ext import db
-from google.appengine.ext import webapp
 from google.appengine.ext.webapp.util import login_required
 from google.appengine.ext.webapp.util import run_wsgi_app
 from oauth2client import GOOGLE_AUTH_URI

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ deps =
     pyyaml
     sphinx>=1.3b2
     sphinx-rtd-theme
+    webapp2
 commands = {toxinidir}/scripts/build-docs
 
 [testenv:pushdocs]


### PR DESCRIPTION
This choice is apparently more robust in situations / runtimes where the import mechanism in `google/appengine/ext/webapp/__init__.py` does not appear to do the right thing.
