### PR TITLE
Added 'state' parameter to step1_get_authorize_url.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1849,7 +1849,7 @@ class OAuth2WebServerFlow(Flow):
     self.params.update(kwargs)
 
   @util.positional(1)
-  def step1_get_authorize_url(self, redirect_uri=None):
+  def step1_get_authorize_url(self, redirect_uri=None, state=None):
     """Returns a URI to redirect to the provider.
 
     Args:
@@ -1876,6 +1876,8 @@ class OAuth2WebServerFlow(Flow):
         'redirect_uri': self.redirect_uri,
         'scope': self.scope,
     }
+    if state is not None:
+      query_params['state'] = state
     if self.login_hint is not None:
       query_params['login_hint'] = self.login_hint
     query_params.update(self.params)

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -981,7 +981,7 @@ class OAuth2WebServerFlowTest(unittest.TestCase):
         )
 
   def test_construct_authorize_url(self):
-    authorize_url = self.flow.step1_get_authorize_url()
+    authorize_url = self.flow.step1_get_authorize_url(state='state+1')
 
     parsed = urllib.parse.urlparse(authorize_url)
     q = urllib.parse.parse_qs(parsed[4])
@@ -990,6 +990,7 @@ class OAuth2WebServerFlowTest(unittest.TestCase):
     self.assertEqual('foo', q['scope'][0])
     self.assertEqual(OOB_CALLBACK_URN, q['redirect_uri'][0])
     self.assertEqual('offline', q['access_type'][0])
+    self.assertEqual('state+1', q['state'][0])
 
   def test_override_flow_via_kwargs(self):
     """Passing kwargs to override defaults."""


### PR DESCRIPTION
This PR adds a state parameter to step1_get_authorize_url. It is added as a query parameter to the autorization URL as described in the OAuth 2.0 spec.

See issue #170 
