### PR TITLE
Pinning mock at version 1.0.1.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py26,py27,py33,py34,pypy,cover
 
 [testenv]
 basedeps = keyring
-           mock
+           mock==1.0.1
            pycrypto==2.6
            webtest
            nose


### PR DESCRIPTION
Upgrading to both 1.1.0 and 1.1.1 causes unexplained failures that need to be investigated. This is a stop-gap measure to keep the tests passing and the changelog of `mock` will need to be inspected.

See https://travis-ci.org/google/oauth2client/builds/70413246 for an example failure (from #220).
