### PR TITLE
Adding autodoc for flask_util module.

### DIFF
--- a/docs/source/oauth2client.rst
+++ b/docs/source/oauth2client.rst
@@ -60,6 +60,14 @@ oauth2client.file module
     :undoc-members:
     :show-inheritance:
 
+oauth2client.flask_util module
+------------------------------
+
+.. automodule:: oauth2client.flask_util
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 oauth2client.gce module
 -----------------------
 


### PR DESCRIPTION
This was added automatically by running `tox -e docs`.

H/T to @craigcitro for making `tox -e docs` do this.

H/T to @jonparrott for adding this module
