### PR TITLE
Adding a high level title to contributing.rst.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,3 +1,6 @@
+Contributing
+============
+
 Contributor License Agreements
 ------------------------------
 


### PR DESCRIPTION
Without it, all the 5 headers in the file show up in the main TOC.

e.g. without this change we have

![screen_shot_001](https://cloud.githubusercontent.com/assets/520669/9102143/e4f2b124-3ba3-11e5-9df9-789dde9b369a.png)

and with it we have

![screen_shot_003](https://cloud.githubusercontent.com/assets/520669/9102157/fd07413a-3ba3-11e5-89a6-b6ed784daf0b.png)
