### PR TITLE
Removing unnecessary top-level TOC for all modules.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ contributor license agreement.
    :maxdepth: 1
    :hidden:
 
-   source/modules
+   source/oauth2client
 
 Supported Python Versions
 -------------------------

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,7 +1,0 @@
-oauth2client
-============
-
-.. toctree::
-   :maxdepth: 4
-
-   oauth2client

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -25,6 +25,8 @@ fi
 
 rm -rf docs/_build/* docs/source/*
 sphinx-apidoc -f -o docs/source oauth2client
+# We only have one package, so modules.rst is overkill.
+rm -f docs/source/modules.rst
 cd docs
 make html
 cd ..


### PR DESCRIPTION
If we had more than one base package, it would be relevant, but we only have oauth2client, so it is irrelevant and just visually distracting.
