### PR TITLE
Unifying all conversions to bytes.

### DIFF
--- a/oauth2client/_helpers.py
+++ b/oauth2client/_helpers.py
@@ -39,15 +39,42 @@ def _json_encode(data):
   return json.dumps(data, separators=(',', ':'))
 
 
+def _to_bytes(value, encoding='ascii'):
+  """Converts a string value to bytes, if necessary.
+
+  Unfortunately, ``six.b`` is insufficient for this task since in
+  Python2 it does not modify ``unicode`` objects.
+
+  Args:
+      value: The string/bytes value to be converted.
+      encoding: The encoding to use to convert unicode to bytes. Defaults
+                to "ascii", which will not allow any characters from ordinals
+                larger than 127. Other useful values are "latin-1", which
+                which will only allows byte ordinals (up to 255) and "utf-8",
+                which will encode any unicode that needs to be.
+
+  Returns:
+      The original value converted to bytes (if unicode) or as passed in
+      if it started out as bytes.
+
+  Raises:
+      ValueError if the value could not be converted to bytes.
+  """
+  result = (value.encode(encoding)
+            if isinstance(value, six.text_type) else value)
+  if isinstance(result, six.binary_type):
+    return result
+  else:
+    raise ValueError('%r could not be converted to bytes' % (value,))
+
+
 def _urlsafe_b64encode(raw_bytes):
-  if isinstance(raw_bytes, six.text_type):
-    raw_bytes = raw_bytes.encode('utf-8')
-  return base64.urlsafe_b64encode(raw_bytes).decode('ascii').rstrip('=')
+  raw_bytes = _to_bytes(raw_bytes, encoding='utf-8')
+  return base64.urlsafe_b64encode(raw_bytes).rstrip(b'=')
 
 
 def _urlsafe_b64decode(b64string):
   # Guard against unicode strings, which base64 can't handle.
-  if isinstance(b64string, six.text_type):
-    b64string = b64string.encode('ascii')
+  b64string = _to_bytes(b64string)
   padded = b64string + b'=' * (4 - len(b64string) % 4)
   return base64.urlsafe_b64decode(padded)

--- a/oauth2client/_openssl_crypt.py
+++ b/oauth2client/_openssl_crypt.py
@@ -18,6 +18,7 @@ import six
 from OpenSSL import crypto
 
 from oauth2client._helpers import _parse_pem_key
+from oauth2client._helpers import _to_bytes
 
 
 class OpenSSLVerifier(object):
@@ -44,10 +45,8 @@ class OpenSSLVerifier(object):
       True if message was signed by the private key associated with the public
       key that this object was constructed with.
     """
-    if isinstance(message, six.text_type):
-      message = message.encode('utf-8')
-    if isinstance(signature, six.text_type):
-      signature = signature.encode('utf-8')
+    message = _to_bytes(message, encoding='utf-8')
+    signature = _to_bytes(signature, encoding='utf-8')
     try:
       crypto.verify(self._pubkey, signature, message, 'sha256')
       return True
@@ -96,8 +95,7 @@ class OpenSSLSigner(object):
     Returns:
       string, The signature of the message for the given key.
     """
-    if isinstance(message, six.text_type):
-      message = message.encode('utf-8')
+    message = _to_bytes(message, encoding='utf-8')
     return crypto.sign(self._key, message, 'sha256')
 
   @staticmethod
@@ -118,8 +116,7 @@ class OpenSSLSigner(object):
     if parsed_pem_key:
       pkey = crypto.load_privatekey(crypto.FILETYPE_PEM, parsed_pem_key)
     else:
-      if isinstance(password, six.text_type):
-        password = password.encode('utf-8')
+      password = _to_bytes(password, encoding='utf-8')
       pkey = crypto.load_pkcs12(key, password).get_privatekey()
     return OpenSSLSigner(pkey)
 
@@ -135,8 +132,7 @@ def pkcs12_key_as_pem(private_key_text, private_key_password):
     String. PEM contents of ``private_key_text``.
   """
   decoded_body = base64.b64decode(private_key_text)
-  if isinstance(private_key_password, six.text_type):
-    private_key_password = private_key_password.encode('ascii')
+  private_key_password = _to_bytes(private_key_password)
 
   pkcs12 = crypto.load_pkcs12(decoded_body, private_key_password)
   return crypto.dump_privatekey(crypto.FILETYPE_PEM,

--- a/oauth2client/_pycrypto_crypt.py
+++ b/oauth2client/_pycrypto_crypt.py
@@ -20,6 +20,7 @@ from Crypto.Util.asn1 import DerSequence
 import six
 
 from oauth2client._helpers import _parse_pem_key
+from oauth2client._helpers import _to_bytes
 from oauth2client._helpers import _urlsafe_b64decode
 
 
@@ -46,8 +47,7 @@ class PyCryptoVerifier(object):
       True if message was signed by the private key associated with the public
       key that this object was constructed with.
     """
-    if isinstance(message, six.text_type):
-      message = message.encode('utf-8')
+    message = _to_bytes(message, encoding='utf-8')
     return PKCS1_v1_5.new(self._pubkey).verify(
         SHA256.new(message), signature)
 
@@ -64,8 +64,7 @@ class PyCryptoVerifier(object):
       Verifier instance.
     """
     if is_x509_cert:
-      if isinstance(key_pem, six.text_type):
-        key_pem = key_pem.encode('ascii')
+      key_pem = _to_bytes(key_pem)
       pemLines = key_pem.replace(b' ', b'').split()
       certDer = _urlsafe_b64decode(b''.join(pemLines[1:-1]))
       certSeq = DerSequence()
@@ -98,8 +97,7 @@ class PyCryptoSigner(object):
     Returns:
       string, The signature of the message for the given key.
     """
-    if isinstance(message, six.text_type):
-      message = message.encode('utf-8')
+    message = _to_bytes(message, encoding='utf-8')
     return PKCS1_v1_5.new(self._key).sign(SHA256.new(message))
 
   @staticmethod

--- a/oauth2client/crypt.py
+++ b/oauth2client/crypt.py
@@ -20,6 +20,7 @@ import logging
 import time
 
 from oauth2client._helpers import _json_encode
+from oauth2client._helpers import _to_bytes
 from oauth2client._helpers import _urlsafe_b64decode
 from oauth2client._helpers import _urlsafe_b64encode
 
@@ -84,14 +85,14 @@ def make_signed_jwt(signer, payload):
       _urlsafe_b64encode(_json_encode(header)),
       _urlsafe_b64encode(_json_encode(payload)),
   ]
-  signing_input = '.'.join(segments)
+  signing_input = b'.'.join(segments)
 
   signature = signer.sign(signing_input)
   segments.append(_urlsafe_b64encode(signature))
 
   logger.debug(str(segments))
 
-  return '.'.join(segments)
+  return b'.'.join(segments)
 
 
 def verify_signed_jwt_with_certs(jwt, certs, audience):
@@ -111,11 +112,12 @@ def verify_signed_jwt_with_certs(jwt, certs, audience):
   Raises:
     AppIdentityError if any checks are failed.
   """
-  segments = jwt.split('.')
+  jwt = _to_bytes(jwt)
+  segments = jwt.split(b'.')
 
   if len(segments) != 3:
     raise AppIdentityError('Wrong number of segments in token: %s' % jwt)
-  signed = '%s.%s' % (segments[0], segments[1])
+  signed = segments[0] + b'.' + segments[1]
 
   signature = _urlsafe_b64decode(segments[2])
 

--- a/oauth2client/devshell.py
+++ b/oauth2client/devshell.py
@@ -17,6 +17,7 @@
 import json
 import os
 
+from oauth2client._helpers import _to_bytes
 from oauth2client import client
 
 
@@ -76,7 +77,7 @@ def _SendRecv():
 
   data = CREDENTIAL_INFO_REQUEST_JSON
   msg = '%s\n%s' % (len(data), data)
-  sock.sendall(msg.encode())
+  sock.sendall(_to_bytes(msg, encoding='utf-8'))
 
   header = sock.recv(6).decode()
   if '\n' not in header:
@@ -133,4 +134,3 @@ class DevshellCredentials(client.GoogleCredentials):
   def serialization_data(self):
     raise NotImplementedError(
         'Cannot serialize Developer Shell credentials.')
-

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -17,6 +17,7 @@ import unittest
 
 from oauth2client._helpers import _json_encode
 from oauth2client._helpers import _parse_pem_key
+from oauth2client._helpers import _to_bytes
 from oauth2client._helpers import _urlsafe_b64decode
 from oauth2client._helpers import _urlsafe_b64encode
 
@@ -49,17 +50,35 @@ class Test__json_encode(unittest.TestCase):
     self.assertEqual(result, """[42,1337]""")
 
 
+class Test__to_bytes(unittest.TestCase):
+
+  def test_with_bytes(self):
+    value = b'bytes-val'
+    self.assertEqual(_to_bytes(value), value)
+
+  def test_with_unicode(self):
+    value = u'string-val'
+    encoded_value = b'string-val'
+    self.assertEqual(_to_bytes(value), encoded_value)
+
+  def test_with_nonstring_type(self):
+    value = object()
+    self.assertRaises(ValueError, _to_bytes, value)
+
+
 class Test__urlsafe_b64encode(unittest.TestCase):
+
+  DEADBEEF_ENCODED = b'ZGVhZGJlZWY'
 
   def test_valid_input_bytes(self):
     test_string = b'deadbeef'
     result = _urlsafe_b64encode(test_string)
-    self.assertEqual(result, u'ZGVhZGJlZWY')
+    self.assertEqual(result, self.DEADBEEF_ENCODED)
 
   def test_valid_input_unicode(self):
     test_string = u'deadbeef'
     result = _urlsafe_b64encode(test_string)
-    self.assertEqual(result, u'ZGVhZGJlZWY')
+    self.assertEqual(result, self.DEADBEEF_ENCODED)
 
 
 class Test__urlsafe_b64decode(unittest.TestCase):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -147,7 +147,7 @@ class CryptTests(unittest.TestCase):
     self._check_jwt_failure('foo.bar.baz', 'Can\'t parse token')
 
     # Bad signature
-    jwt = 'foo.%s.baz' % crypt._urlsafe_b64encode('{"a":"b"}')
+    jwt = b'.'.join([b'foo', crypt._urlsafe_b64encode('{"a":"b"}'), b'baz'])
     self._check_jwt_failure(jwt, 'Invalid token signature')
 
     # No expiration


### PR DESCRIPTION
Also making sure the _urlsafe_b64encode returns bytes and updating dependent code with the change in return type.

**NOTE**: This doesn't address the opposite direction, i.e. `a.decode('utf-8')` where is a `bytes` (or `str`) object.
