### PR TITLE
Using a separate autodoc page for each module.

### DIFF
--- a/docs/source/oauth2client.appengine.rst
+++ b/docs/source/oauth2client.appengine.rst
@@ -1,0 +1,7 @@
+oauth2client.appengine module
+=============================
+
+.. automodule:: oauth2client.appengine
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.client.rst
+++ b/docs/source/oauth2client.client.rst
@@ -1,0 +1,7 @@
+oauth2client.client module
+==========================
+
+.. automodule:: oauth2client.client
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.clientsecrets.rst
+++ b/docs/source/oauth2client.clientsecrets.rst
@@ -1,0 +1,7 @@
+oauth2client.clientsecrets module
+=================================
+
+.. automodule:: oauth2client.clientsecrets
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.crypt.rst
+++ b/docs/source/oauth2client.crypt.rst
@@ -1,0 +1,7 @@
+oauth2client.crypt module
+=========================
+
+.. automodule:: oauth2client.crypt
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.devshell.rst
+++ b/docs/source/oauth2client.devshell.rst
@@ -1,0 +1,7 @@
+oauth2client.devshell module
+============================
+
+.. automodule:: oauth2client.devshell
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.django_orm.rst
+++ b/docs/source/oauth2client.django_orm.rst
@@ -1,0 +1,7 @@
+oauth2client.django_orm module
+==============================
+
+.. automodule:: oauth2client.django_orm
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.file.rst
+++ b/docs/source/oauth2client.file.rst
@@ -1,0 +1,7 @@
+oauth2client.file module
+========================
+
+.. automodule:: oauth2client.file
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.flask_util.rst
+++ b/docs/source/oauth2client.flask_util.rst
@@ -1,0 +1,7 @@
+oauth2client.flask_util module
+==============================
+
+.. automodule:: oauth2client.flask_util
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.gce.rst
+++ b/docs/source/oauth2client.gce.rst
@@ -1,0 +1,7 @@
+oauth2client.gce module
+=======================
+
+.. automodule:: oauth2client.gce
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.keyring_storage.rst
+++ b/docs/source/oauth2client.keyring_storage.rst
@@ -1,0 +1,7 @@
+oauth2client.keyring_storage module
+===================================
+
+.. automodule:: oauth2client.keyring_storage
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.locked_file.rst
+++ b/docs/source/oauth2client.locked_file.rst
@@ -1,0 +1,7 @@
+oauth2client.locked_file module
+===============================
+
+.. automodule:: oauth2client.locked_file
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.multistore_file.rst
+++ b/docs/source/oauth2client.multistore_file.rst
@@ -1,0 +1,7 @@
+oauth2client.multistore_file module
+===================================
+
+.. automodule:: oauth2client.multistore_file
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.old_run.rst
+++ b/docs/source/oauth2client.old_run.rst
@@ -1,0 +1,7 @@
+oauth2client.old_run module
+===========================
+
+.. automodule:: oauth2client.old_run
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.rst
+++ b/docs/source/oauth2client.rst
@@ -4,142 +4,25 @@ oauth2client package
 Submodules
 ----------
 
-oauth2client.appengine module
------------------------------
+.. toctree::
 
-.. automodule:: oauth2client.appengine
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.client module
---------------------------
-
-.. automodule:: oauth2client.client
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.clientsecrets module
----------------------------------
-
-.. automodule:: oauth2client.clientsecrets
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.crypt module
--------------------------
-
-.. automodule:: oauth2client.crypt
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.devshell module
-----------------------------
-
-.. automodule:: oauth2client.devshell
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.django_orm module
-------------------------------
-
-.. automodule:: oauth2client.django_orm
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.file module
-------------------------
-
-.. automodule:: oauth2client.file
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.flask_util module
-------------------------------
-
-.. automodule:: oauth2client.flask_util
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.gce module
------------------------
-
-.. automodule:: oauth2client.gce
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.keyring_storage module
------------------------------------
-
-.. automodule:: oauth2client.keyring_storage
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.locked_file module
--------------------------------
-
-.. automodule:: oauth2client.locked_file
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.multistore_file module
------------------------------------
-
-.. automodule:: oauth2client.multistore_file
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.old_run module
----------------------------
-
-.. automodule:: oauth2client.old_run
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.service_account module
------------------------------------
-
-.. automodule:: oauth2client.service_account
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.tools module
--------------------------
-
-.. automodule:: oauth2client.tools
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.util module
-------------------------
-
-.. automodule:: oauth2client.util
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-oauth2client.xsrfutil module
-----------------------------
-
-.. automodule:: oauth2client.xsrfutil
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   oauth2client.appengine
+   oauth2client.client
+   oauth2client.clientsecrets
+   oauth2client.crypt
+   oauth2client.devshell
+   oauth2client.django_orm
+   oauth2client.file
+   oauth2client.flask_util
+   oauth2client.gce
+   oauth2client.keyring_storage
+   oauth2client.locked_file
+   oauth2client.multistore_file
+   oauth2client.old_run
+   oauth2client.service_account
+   oauth2client.tools
+   oauth2client.util
+   oauth2client.xsrfutil
 
 Module contents
 ---------------

--- a/docs/source/oauth2client.service_account.rst
+++ b/docs/source/oauth2client.service_account.rst
@@ -1,0 +1,7 @@
+oauth2client.service_account module
+===================================
+
+.. automodule:: oauth2client.service_account
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.tools.rst
+++ b/docs/source/oauth2client.tools.rst
@@ -1,0 +1,7 @@
+oauth2client.tools module
+=========================
+
+.. automodule:: oauth2client.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.util.rst
+++ b/docs/source/oauth2client.util.rst
@@ -1,0 +1,7 @@
+oauth2client.util module
+========================
+
+.. automodule:: oauth2client.util
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.xsrfutil.rst
+++ b/docs/source/oauth2client.xsrfutil.rst
@@ -1,0 +1,7 @@
+oauth2client.xsrfutil module
+============================
+
+.. automodule:: oauth2client.xsrfutil
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -24,7 +24,7 @@ if [[ -z "${SKIP_GAE_SDK}" ]]; then
 fi
 
 rm -rf docs/_build/* docs/source/*
-sphinx-apidoc -f -o docs/source oauth2client
+sphinx-apidoc --separate --force -o docs/source oauth2client
 # We only have one package, so modules.rst is overkill.
 rm -f docs/source/modules.rst
 cd docs


### PR DESCRIPTION
I was working on #257 and reading http://sphinx-doc.org/man/sphinx-apidoc.html and noticed that `--separate` is a useful flag (to keep the docs pages relatively small and digestible).
