### PR TITLE
Making docs tox target fail on untracked changes.

### DIFF
--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -27,6 +27,13 @@ rm -rf docs/_build/* docs/source/*
 sphinx-apidoc -f -o docs/source oauth2client
 # We only have one package, so modules.rst is overkill.
 rm -f docs/source/modules.rst
+
+# If anything has changed
+if [[ -n "$(git diff -- docs/)" ]]; then
+    echo "sphinx-apidoc generated changes that are not checked in to version control."
+    exit 1
+fi
+
 cd docs
 make html
 cd ..


### PR DESCRIPTION
Checking if sphinx-apidoc generates new content and failing the script if the content is not checked in to version control.

Fixes #257.

@nathanielmanistaatgoogle I debated adding a `tox` target that would just generate the new content, but `tox -e docs` will still do this before failing, after which a user could then

``` bash
$ git add docs/
$ tox -e docs  # This time it won't fail
```
