### PR TITLE
Making sure libgmp is ignored in pypy tox env.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ basedeps = keyring
            flask
 deps = {[testenv]basedeps}
        django
-setenv = PYTHONPATH=../google_appengine
+setenv =
+    PYTHONPATH=../google_appengine
+    pypy: with_gmp=no
 commands = nosetests --ignore-files=test_appengine\.py {posargs}
 
 [testenv:cover]


### PR DESCRIPTION
This is because when libgmp is detected, installing PyCrypto tries to build _fastmath.c. But in PyPy this
fails because _fastmath.c tries to access parts of the CPython implementation.

See for `with_gmp=no` suggestion:
https://github.com/dlitz/pycrypto/pull/59#issuecomment-86569001
