### PR TITLE
Use pypy-2.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
   - TOX_ENV=system-tests
   - TOX_ENV=system-tests3
 install:
-- pip install tox
+- ./scripts/install.sh
 script:
-- tox -e $TOX_ENV
+- ./scripts/run.sh
 after_success:
 - if [[ "${TOX_ENV}" == "py27" ]]; then tox -e coveralls; fi
 notifications:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ev
+
+pip install tox

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,3 +17,11 @@
 set -ev
 
 pip install tox
+if [[ "${TOX_ENV}" == "pypy" ]]; then
+    git clone https://github.com/yyuu/pyenv.git ${HOME}/.pyenv
+    PYENV_ROOT="${HOME}/.pyenv"
+    PATH="${PYENV_ROOT}/bin:${PATH}"
+    eval "$(pyenv init -)"
+    pyenv install pypy-2.6.0
+    pyenv global pypy-2.6.0
+fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -16,4 +16,10 @@
 
 set -ev
 
+if [[ "${TOX_ENV}" == "pypy" ]]; then
+    PYENV_ROOT="${HOME}/.pyenv"
+    PATH="${PYENV_ROOT}/bin:${PATH}"
+    eval "$(pyenv init -)"
+    pyenv global pypy-2.6.0
+fi
 tox -e ${TOX_ENV}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ev
+
+tox -e ${TOX_ENV}


### PR DESCRIPTION
This is the latest version and will hopefully be updated in Travis soon (from pypy-2.5).

This PR makes a custom pyenv with pypy-2.6 when running the `pypy` tox env.

Fixes #261.
