### PR TITLE
Updating docs and CONTRIBUTING file with pypy tips.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,10 @@ Running Tests
     $ tox
     ```
 
+-   In order to run the `pypy` environment (in `tox`) you'll need at
+    least version 2.6 of `pypy` installed. See the [docs][13] for
+    more information.
+
 Running System Tests
 --------------------
 
@@ -191,3 +195,4 @@ we'll be able to accept your pull requests.
 [10]: #fork-oauth2client
 [11]: #include-tests
 [12]: #make-the-pull-request
+[13]: http://oauth2client.readthedocs.org/en/latest/#using-pypy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,15 +11,67 @@ information about using OAuth2 with Google APIs
 Getting started
 ---------------
 
-We recommend installing via ``pip``::
+We recommend installing via ``pip``:
 
-  $ pip install --upgrade oauth2client
+.. code-block:: bash
 
-You can also install from source::
+    $ pip install --upgrade oauth2client
 
-  $ git clone https://github.com/google/oauth2client
-  $ cd oauth2client
-  $ python setup.py install
+You can also install from source:
+
+.. code-block:: bash
+
+    $ git clone https://github.com/google/oauth2client
+    $ cd oauth2client
+    $ python setup.py install
+
+Using ``pypy``
+--------------
+
+-   In order to use crypto libraries (e.g. for service accounts) you will
+    need to install one of ``pycrypto`` or ``pyOpenSSL``.
+-   Using ``pycrypto`` with ``pypy`` will be in general problematic. If
+    ``libgmp`` is installed on your machine, the ``pycrypto`` install will
+    attempt to build ``_fastmath.c``. However, this file uses CPython
+    implementation details and hence can't be built in ``pypy`` (as of
+    ``pypy`` 2.6 and ``pycrypto`` 2.6.1). In order to install
+
+    .. code-block:: bash
+
+        with_gmp=no pip install --upgrade pycrypto
+
+    See discussions on the `pypy issue tracker`_ and the
+    `pycrypto issue tracker`_.
+
+-   Using ``pyOpenSSL`` with versions of ``pypy`` before 2.6 may be in general
+    problematic since ``pyOpenSSL`` depends on the ``cryptography`` library.
+    For versions of ``cryptography`` before 1.0, importing ``pyOpenSSL``
+    with it caused `massive startup costs`_. In order to address this
+    slow startup, ``cryptography`` 1.0 made some `changes`_ in how it used
+    ``cffi`` when means it can't be used on versions of ``pypy`` before 2.6.
+
+    The default version of ``pypy`` you get when installed
+
+    .. code-block:: bash
+
+        apt-get install pypy pypy-dev
+
+    on `Ubuntu 14.04`_ is 2.2.1. In order to upgrade, you'll need to use
+    the `pypy/ppa PPA`_:
+
+    .. code-block:: bash
+
+        apt-get purge pypy pypy-dev
+        add-apt-repository ppa:pypy/ppa
+        apt-get update
+        apt-get install pypy pypy-dev
+
+.. _pypy issue tracker: https://bitbucket.org/pypy/pypy/issues/997
+.. _pycrypto issue tracker: https://github.com/dlitz/pycrypto/pull/59
+.. _massive startup costs: https://github.com/pyca/pyopenssl/issues/137
+.. _changes: https://github.com/pyca/cryptography/issues/2275#issuecomment-130751514
+.. _Ubuntu 14.04: http://packages.ubuntu.com/trusty/pypy
+.. _pypy/ppa PPA: https://launchpad.net/~pypy/+archive/ubuntu/ppa
 
 Downloads
 ^^^^^^^^^


### PR DESCRIPTION
As it turns out, both of our optional crypto dependencies have issues in pypy.

See it on https://github.com/dhermes/oauth2client/blob/add-pypy-note-to-contributing/CONTRIBUTING.md

@nathanielmanistaatgoogle I have two potential uneasy things here
1. Maybe this should go in `README`
2. Maybe it should be in its own section in `CONTRIBUTING` (rather than in "Running Tests")
