### PR TITLE
Removing import OpenSSL hack.

### DIFF
--- a/oauth2client/_openssl_crypt.py
+++ b/oauth2client/_openssl_crypt.py
@@ -15,6 +15,7 @@
 
 import base64
 import six
+from OpenSSL import crypto
 
 from oauth2client._helpers import _parse_pem_key
 
@@ -43,7 +44,6 @@ class OpenSSLVerifier(object):
       True if message was signed by the private key associated with the public
       key that this object was constructed with.
     """
-    from OpenSSL import crypto  # Delay import due to 0.5s import time.
     if isinstance(message, six.text_type):
       message = message.encode('utf-8')
     if isinstance(signature, six.text_type):
@@ -69,7 +69,6 @@ class OpenSSLVerifier(object):
     Raises:
       OpenSSL.crypto.Error if the key_pem can't be parsed.
     """
-    from OpenSSL import crypto  # Delay import due to 0.5s import time.
     if is_x509_cert:
       pubkey = crypto.load_certificate(crypto.FILETYPE_PEM, key_pem)
     else:
@@ -97,7 +96,6 @@ class OpenSSLSigner(object):
     Returns:
       string, The signature of the message for the given key.
     """
-    from OpenSSL import crypto  # Delay import due to 0.5s import time.
     if isinstance(message, six.text_type):
       message = message.encode('utf-8')
     return crypto.sign(self._key, message, 'sha256')
@@ -116,7 +114,6 @@ class OpenSSLSigner(object):
     Raises:
       OpenSSL.crypto.Error if the key can't be parsed.
     """
-    from OpenSSL import crypto  # Delay import due to 0.5s import time.
     parsed_pem_key = _parse_pem_key(key)
     if parsed_pem_key:
       pkey = crypto.load_privatekey(crypto.FILETYPE_PEM, parsed_pem_key)
@@ -137,7 +134,6 @@ def pkcs12_key_as_pem(private_key_text, private_key_password):
   Returns:
     String. PEM contents of ``private_key_text``.
   """
-  from OpenSSL import crypto  # Delay import due to 0.5s import time.
   decoded_body = base64.b64decode(private_key_text)
   if isinstance(private_key_password, six.text_type):
     private_key_password = private_key_password.encode('ascii')

--- a/oauth2client/crypt.py
+++ b/oauth2client/crypt.py
@@ -15,10 +15,8 @@
 # limitations under the License.
 """Crypto-related routines for oauth2client."""
 
-import imp
 import json
 import logging
-import os
 import time
 
 from oauth2client._helpers import _json_encode
@@ -38,37 +36,7 @@ class AppIdentityError(Exception):
   pass
 
 
-def _TryOpenSslImport():
-  """Import OpenSSL, avoiding the explicit import where possible.
-
-  Importing OpenSSL 0.14 can take up to 0.5s, which is a large price
-  to pay at module import time. However, it's also possible for
-  ``imp.find_module`` to fail to find the module, even when it's
-  installed. (This is the case in various exotic environments,
-  including some relevant for Google.) So we first try a fast-path,
-  and fall back to the slow import as needed.
-
-  Args:
-    None
-  Returns:
-    None
-  Raises:
-    ImportError if OpenSSL is unavailable.
-
-  """
-  try:
-    _, _package_dir, _ = imp.find_module('OpenSSL')
-    if not (os.path.isfile(os.path.join(_package_dir, 'crypto.py')) or
-            os.path.isfile(os.path.join(_package_dir, 'crypto.so')) or
-            os.path.isdir(os.path.join(_package_dir, 'crypto'))):
-      raise ImportError('No module named OpenSSL.crypto')
-    return
-  except ImportError:
-    import OpenSSL.crypto
-
-
 try:
-  _TryOpenSslImport()
   from oauth2client._openssl_crypt import OpenSSLVerifier
   from oauth2client._openssl_crypt import OpenSSLSigner
   from oauth2client._openssl_crypt import pkcs12_key_as_pem

--- a/tests/test_crypt.py
+++ b/tests/test_crypt.py
@@ -66,54 +66,6 @@ class Test_pkcs12_key_as_pem(unittest.TestCase):
     password = u'notasecret'
     self._succeeds_helper(password)
 
-  def test_without_openssl(self):
-    import imp
-    imp_find_module = imp.find_module
-    orig_sys_path = sys.path
-    def find_module(module_name):
-      raise ImportError('No module named %s' % module_name)
-    try:
-      for m in list(sys.modules):
-        if m.startswith('OpenSSL'):
-          sys.modules.pop(m)
-      sys.path = []
-      imp.find_module = find_module
-      reload(crypt)
-      self.assertRaises(NotImplementedError, crypt.pkcs12_key_as_pem,
-                        'FOO', 'BAR')
-    finally:
-      sys.path = orig_sys_path
-      imp.find_module = imp_find_module
-      import OpenSSL.crypto
-      reload(crypt)
-
-  def test_without_openssl_crypto(self):
-    import imp
-    imp_find_module = imp.find_module
-    orig_sys_path = sys.path
-    orig_isfile = os.path.isfile
-    openssl_module = imp.find_module('OpenSSL')
-    def find_module(module_name):
-      if module_name == 'OpenSSL':
-        return openssl_module
-      raise ImportError('No module named %s' % module_name)
-    try:
-      for m in list(sys.modules):
-        if m.startswith('OpenSSL'):
-          sys.modules.pop(m)
-      sys.path = []
-      imp.find_module = find_module
-      os.path.isfile = lambda filename: False
-      reload(crypt)
-      self.assertRaises(NotImplementedError, crypt.pkcs12_key_as_pem,
-                        'FOO', 'BAR')
-    finally:
-      sys.path = orig_sys_path
-      imp.find_module = imp_find_module
-      os.path.isfile = orig_isfile
-      import OpenSSL.crypto
-      reload(crypt)
-
   def test_with_nonsense_key(self):
     from OpenSSL import crypto
     credentials = self._make_signed_jwt_creds(private_key=b'NOT_A_KEY')

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@ envlist = py26,py27,py33,py34,pypy,cover
 [testenv]
 basedeps = keyring
            mock==1.0.1
-           pycrypto==2.6
+           pycrypto>=2.6
+           cryptography>=1.0
+           pyopenssl>=0.14
            webtest
            nose
            flask
 deps = {[testenv]basedeps}
        django
-       pyopenssl==0.14
 setenv = PYTHONPATH=../google_appengine
 commands = nosetests --ignore-files=test_appengine\.py {posargs}
 
@@ -47,19 +48,6 @@ commands = {toxinidir}/scripts/build-docs
 basepython = python2.6
 deps = {[testenv]basedeps}
        django>=1.5,<1.6
-       pyopenssl==0.14
-
-[testenv:py26openssl13]
-basepython = python2.6
-deps = {[testenv]basedeps}
-       django>=1.5,<1.6
-       pyopenssl<0.14
-
-[testenv:py27openssl13]
-basepython = python2.7
-deps = {[testenv]basedeps}
-       django>=1.5,<1.6
-       pyopenssl<0.14
 
 [testenv:system-tests]
 basepython =
@@ -67,8 +55,9 @@ basepython =
 commands =
     {toxinidir}/scripts/run_system_tests.sh
 deps =
-    pycrypto==2.6
-    pyopenssl==0.14
+    pycrypto>=2.6
+    cryptography>=1.0
+    pyopenssl>=0.14
 passenv = GOOGLE_* OAUTH2CLIENT_* TRAVIS*
 
 [testenv:system-tests3]
@@ -77,6 +66,7 @@ basepython =
 commands =
     {toxinidir}/scripts/run_system_tests.sh
 deps =
-    pycrypto==2.6
-    pyopenssl==0.14
+    pycrypto>=2.6
+    cryptography>=1.0
+    pyopenssl>=0.14
 passenv = {[testenv:system-tests]passenv}


### PR DESCRIPTION
No longer needed since the cryptography 1.0 release has fixed the slow import (due to changes in the way cffi was used).

This somewhat collides with #262
