### PR TITLE
Adding _from_bytes helpers as a foil for _to_bytes.

### DIFF
--- a/oauth2client/_helpers.py
+++ b/oauth2client/_helpers.py
@@ -68,6 +68,27 @@ def _to_bytes(value, encoding='ascii'):
     raise ValueError('%r could not be converted to bytes' % (value,))
 
 
+def _from_bytes(value):
+  """Converts bytes to a string value, if necessary.
+
+  Args:
+      value: The string/bytes value to be converted.
+
+  Returns:
+      The original value converted to unicode (if bytes) or as passed in
+      if it started out as unicode.
+
+  Raises:
+      ValueError if the value could not be converted to unicode.
+  """
+  result = (value.decode('utf-8')
+            if isinstance(value, six.binary_type) else value)
+  if isinstance(result, six.text_type):
+    return result
+  else:
+    raise ValueError('%r could not be converted to unicode' % (value,))
+
+
 def _urlsafe_b64encode(raw_bytes):
   raw_bytes = _to_bytes(raw_bytes, encoding='utf-8')
   return base64.urlsafe_b64encode(raw_bytes).rstrip(b'=')

--- a/oauth2client/crypt.py
+++ b/oauth2client/crypt.py
@@ -19,6 +19,7 @@ import json
 import logging
 import time
 
+from oauth2client._helpers import _from_bytes
 from oauth2client._helpers import _json_encode
 from oauth2client._helpers import _to_bytes
 from oauth2client._helpers import _urlsafe_b64decode
@@ -124,7 +125,7 @@ def verify_signed_jwt_with_certs(jwt, certs, audience):
   # Parse token.
   json_body = _urlsafe_b64decode(segments[1])
   try:
-    parsed = json.loads(json_body.decode('utf-8'))
+    parsed = json.loads(_from_bytes(json_body))
   except:
     raise AppIdentityError('Can\'t parse token: %s' % json_body)
 

--- a/oauth2client/gce.py
+++ b/oauth2client/gce.py
@@ -23,6 +23,7 @@ import json
 import logging
 from six.moves import urllib
 
+from oauth2client._helpers import _from_bytes
 from oauth2client import util
 from oauth2client.client import AccessTokenRefreshError
 from oauth2client.client import AssertionCredentials
@@ -63,7 +64,7 @@ class AppAssertionCredentials(AssertionCredentials):
 
   @classmethod
   def from_json(cls, json_data):
-    data = json.loads(json_data)
+    data = json.loads(_from_bytes(json_data))
     return AppAssertionCredentials(data['scope'])
 
   def _refresh(self, http_request):
@@ -81,6 +82,7 @@ class AppAssertionCredentials(AssertionCredentials):
     query = '?scope=%s' % urllib.parse.quote(self.scope, '')
     uri = META.replace('{?scope}', query)
     response, content = http_request(uri)
+    content = _from_bytes(content)
     if response.status == 200:
       try:
         d = json.loads(content)

--- a/oauth2client/service_account.py
+++ b/oauth2client/service_account.py
@@ -18,7 +18,6 @@ This credentials class is implemented on top of rsa library.
 """
 
 import base64
-import six
 import time
 
 from pyasn1.codec.ber import decoder

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+from oauth2client._helpers import _from_bytes
 from oauth2client._helpers import _json_encode
 from oauth2client._helpers import _parse_pem_key
 from oauth2client._helpers import _to_bytes
@@ -64,6 +65,22 @@ class Test__to_bytes(unittest.TestCase):
   def test_with_nonstring_type(self):
     value = object()
     self.assertRaises(ValueError, _to_bytes, value)
+
+
+class Test__from_bytes(unittest.TestCase):
+
+  def test_with_unicode(self):
+    value = u'bytes-val'
+    self.assertEqual(_from_bytes(value), value)
+
+  def test_with_bytes(self):
+    value = b'string-val'
+    decoded_value = u'string-val'
+    self.assertEqual(_from_bytes(value), decoded_value)
+
+  def test_with_nonstring_type(self):
+    value = object()
+    self.assertRaises(ValueError, _from_bytes, value)
 
 
 class Test__urlsafe_b64encode(unittest.TestCase):

--- a/tests/test_appengine.py
+++ b/tests/test_appengine.py
@@ -28,8 +28,8 @@ import json
 import os
 import time
 import unittest
-import urllib
-import urlparse
+
+from six.moves import urllib
 
 import dev_appserver
 dev_appserver.fix_sys_path()
@@ -550,7 +550,7 @@ class DecoratorTests(unittest.TestCase):
     self.assertEqual(self.decorator.credentials, None)
     response = self.app.get('http://localhost/foo_path')
     self.assertTrue(response.status.startswith('302'))
-    q = urlparse.parse_qs(response.headers['Location'].split('?', 1)[1])
+    q = urllib.parse.parse_qs(response.headers['Location'].split('?', 1)[1])
     self.assertEqual('http://localhost/oauth2callback', q['redirect_uri'][0])
     self.assertEqual('foo_client_id', q['client_id'][0])
     self.assertEqual('foo_scope bar_scope', q['scope'][0])
@@ -571,10 +571,10 @@ class DecoratorTests(unittest.TestCase):
       self.assertEqual('http://localhost/foo_path', parts[0])
       self.assertEqual(None, self.decorator.credentials)
       if self.decorator._token_response_param:
-        response_query = urlparse.parse_qs(parts[1])
+        response_query = urllib.parse.parse_qs(parts[1])
         response = response_query[self.decorator._token_response_param][0]
         self.assertEqual(Http2Mock.content,
-                         json.loads(urllib.unquote(response)))
+                         json.loads(urllib.parse.unquote(response)))
       self.assertEqual(self.decorator.flow, self.decorator._tls.flow)
       self.assertEqual(self.decorator.credentials,
                        self.decorator._tls.credentials)
@@ -605,7 +605,7 @@ class DecoratorTests(unittest.TestCase):
     # Invalid Credentials should start the OAuth dance again.
     response = self.app.get('/foo_path')
     self.assertTrue(response.status.startswith('302'))
-    q = urlparse.parse_qs(response.headers['Location'].split('?', 1)[1])
+    q = urllib.parse.parse_qs(response.headers['Location'].split('?', 1)[1])
     self.assertEqual('http://localhost/oauth2callback', q['redirect_uri'][0])
 
   def test_storage_delete(self):
@@ -650,7 +650,7 @@ class DecoratorTests(unittest.TestCase):
     self.assertEqual('200 OK', response.status)
     self.assertEqual(False, self.decorator.has_credentials())
     url = self.decorator.authorize_url()
-    q = urlparse.parse_qs(url.split('?', 1)[1])
+    q = urllib.parse.parse_qs(url.split('?', 1)[1])
     self.assertEqual('http://localhost/oauth2callback', q['redirect_uri'][0])
     self.assertEqual('foo_client_id', q['client_id'][0])
     self.assertEqual('foo_scope bar_scope', q['scope'][0])

--- a/tests/test_oauth2client.py
+++ b/tests/test_oauth2client.py
@@ -801,8 +801,8 @@ class BasicCredentialsTests(unittest.TestCase):
     http = credentials.authorize(http)
     http.request(u'http://example.com', method=u'GET', headers={u'foo': u'bar'})
     for k, v in six.iteritems(http.headers):
-      self.assertEqual(six.binary_type, type(k))
-      self.assertEqual(six.binary_type, type(v))
+      self.assertTrue(isinstance(k, six.binary_type))
+      self.assertTrue(isinstance(v, six.binary_type))
 
     # Test again with unicode strings that can't simply be converted to ASCII.
     try:


### PR DESCRIPTION
@nathanielmanistaatgoogle This is the child of #157.

I labeled it don't merge because I essentially just looked around for `.decode` and tried to preserve a lot of the stuff from the other PR, but haven't written any new tests.

Let's discuss (and I'll iterate) before merging.

**UPDATE**: I should note that I rebased the original PR if anyone wants to have a look: https://github.com/dhermes/oauth2client/tree/pr-157-rebased

Fixes #239 (~~but no tests yet~~ tested by `AssertionCredentialsTests.test_refresh_success_bytes`)
