### PR TITLE
Add JWT access token support for service accounts

### DIFF
--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -76,9 +76,6 @@ class ServiceAccountCredentialsTests(unittest.TestCase):
     self.assertEqual(self.service_account_email,
                      self.credentials.service_account_email)
 
-  def test_create_scoped_required_without_scopes(self):
-    self.assertTrue(self.credentials.create_scoped_required())
-
   def test_create_scoped_required_with_scopes(self):
     self.credentials = _ServiceAccountCredentials(self.service_account_id,
                                                   self.service_account_email,


### PR DESCRIPTION
This is similar to #161, but takes into account the intended use case of simply 'promoting' an assertion to using a self-issued JWT access token instead of [something completely different](https://www.youtube.com/watch?v=K2P86C-1x3o).

But, I'm not quite sure of the appropriate way to test this. There's some test code that covers it (apparently the test code generated the assertion even when the old `create_scoped_required` would have returned `True`), but nothing particularly functional.

It might negatively interact with the spirit of #211.

cc @nathanielmanistaatgoogle @anthmgoogle #252 #253
