### PR TITLE
Adding htmlcov/ directory to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/_build
 .coverage
 coverage.xml
 nosetests.xml
+htmlcov/
 
 # Files with private / local data
 scripts/local_test_setup


### PR DESCRIPTION
This directory is HTML output generated by

```
$ coverage html
```

and can be used to find things such as branch misses in tests.

@nathanielmanistaatgoogle see https://github.com/google/oauth2client/pull/282#issuecomment-134402512 for some context
