### PR TITLE
Combining appengine tests into coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,25 +13,49 @@ basedeps = keyring
 deps = {[testenv]basedeps}
        django
 setenv =
-    PYTHONPATH=../google_appengine
     pypy: with_gmp=no
 commands = nosetests --ignore-files=test_appengine\.py {posargs}
 
-[testenv:cover]
+[coverbase]
 basepython = python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage --cover-package=oauth2client --nocapture --cover-erase --cover-tests --cover-branches --ignore-files=test_appengine\.py --cover-min-percentage=60
+    nosetests \
+      --with-coverage \
+      --cover-package=oauth2client \
+      --cover-erase \
+      --cover-tests \
+      --cover-branches \
+      --ignore-files=test_appengine\.py
+    nosetests \
+      --with-coverage \
+      --cover-package=oauth2client.appengine \
+      --with-gae \
+      --cover-tests \
+      --cover-branches \
+      --gae-application=tests/data \
+      --gae-lib-root={env:GAE_PYTHONPATH} \
+      --logging-level=INFO \
+      tests/test_appengine.py
 deps = {[testenv]deps}
     coverage
-    nosexcover
+    nosegae
+
+[testenv:cover]
+basepython = {[coverbase]basepython}
+commands =
+    {[coverbase]commands}
+    coverage report --show-missing --fail-under 80
+deps =
+    {[coverbase]deps}
 
 [testenv:coveralls]
-basepython = {[testenv:cover]basepython}
+basepython = {[coverbase]basepython}
 commands =
-    {[testenv:cover]commands}
+    {[coverbase]commands}
+    coverage report --show-missing
     coveralls
 deps =
-    {[testenv:cover]deps}
+    {[coverbase]deps}
     coveralls
 passenv = {[testenv:system-tests]passenv}
 
@@ -56,7 +80,7 @@ basepython = python2.7
 deps = {[testenv]basedeps}
        nosegae
 commands =
-    nosetests --with-gae --gae-application=tests/data --logging-level=INFO {posargs} tests/test_appengine.py
+    nosetests --with-gae --gae-application=tests/data --logging-level=INFO tests/test_appengine.py
 setenv:
     PYTHONPATH={env:GAE_PYTHONPATH:}
 


### PR DESCRIPTION
Adds appengine tests to coverage tox env. The output from `tox -e coverage` is misleading:

```
 ~  workspace  oauth2client  master  $  tox -e cover
GLOB sdist-make: /Users/jonwayne/workspace/oauth2client/setup.py
cover inst-nodeps: /Users/jonwayne/workspace/oauth2client/.tox/dist/oauth2client-1.4.12.zip
cover installed: beautifulsoup4==4.4.0,cffi==1.2.1,coverage==3.7.1,cryptography==1.0,Django==1.8.4,enum34==1.0.4,Flask==0.10.1,funcsigs==0.4,httplib2==0.9.1,idna==2.0,ipaddress==1.0.14,itsdangerous==0.24,Jinja2==2.8,keyring==5.4,MarkupSafe==0.23,mock==1.3.0,nose==1.3.7,NoseGAE==0.5.7,oauth2client==1.4.12,pbr==1.6.0,pyasn1==0.1.8,pyasn1-modules==0.0.7,pycparser==2.14,pycrypto==2.6.1,pyOpenSSL==0.15.1,rsa==3.2,six==1.9.0,waitress==0.8.9,WebOb==1.4.1,WebTest==2.0.18,Werkzeug==0.10.4,wheel==0.24.0
cover runtests: PYTHONHASHSEED='4171150552'
cover runtests: commands[0] | nosetests --with-coverage --cover-package=oauth2client --cover-erase --cover-tests --cover-branches --ignore-files=test_appengine\.py
.............................................................................................................................................................................................................................................................................
Name                           Stmts   Miss Branch BrMiss  Cover   Missing
--------------------------------------------------------------------------
oauth2client                       7      0      0      0   100%
oauth2client._helpers             27      0      6      0   100%
oauth2client._openssl_crypt       41      0      4      0   100%
oauth2client._pycrypto_crypt      40      0      4      0   100%
oauth2client.client              725     83    207     44    86%   57-58, 164, 206, 215, 224, 232, 292-296, 355, 365, 372, 724, 741, 776, 889, 892-894, 931-932, 1221, 1237, 1258, 1345, 1418-1422, 1489-1491, 1495-1497, 1551, 1572, 1701, 1875-1896, 1999-2004, 2007, 2017, 2029-2067, 2093, 2095, 2098, 2113, 2222, 2227-2233
oauth2client.clientsecrets        49      0     18      0   100%
oauth2client.crypt                87     14     28      6    83%   44-49, 54-56, 62-66, 153, 167
oauth2client.devshell             53      0      8      0   100%
oauth2client.django_orm           68     26     22     14    56%   46, 48, 53, 71, 73, 78, 101-104, 112-120, 131-140, 145-146
oauth2client.file                 47      0      4      0   100%
oauth2client.flask_util          167      0     40      0   100%
oauth2client.gce                  39      0      4      0   100%
oauth2client.keyring_storage      29      0      2      0   100%
oauth2client.locked_file         183    101     64     47    40%   91, 100, 104, 124-158, 162-169, 173, 196, 216-230, 239-240, 245-329, 351, 356
oauth2client.multistore_file     165     17     24      7    87%   287-294, 360-363, 368-369, 372, 379-380, 386-388, 466-467
oauth2client.service_account      54      0      0      0   100%
oauth2client.tools               109     65     18     16    36%   54-55, 165-239, 244, 249, 252
oauth2client.util                 55     12     18      7    74%   138-141, 148-149, 219-226
oauth2client.xsrfutil             43      0     10      0   100%
--------------------------------------------------------------------------
TOTAL                           1988    318    481    141    81%
----------------------------------------------------------------------
Ran 269 tests in 8.911s

OK
cover runtests: commands[1] | nosetests --with-coverage --cover-package=oauth2client --with-gae --cover-tests --cover-branches --gae-application=tests/data --gae-lib-root=/Users/jonwayne/Downloads/google_appengine --logging-level=INFO tests/test_appengine.py
...................................
Name                           Stmts   Miss Branch BrMiss  Cover   Missing
--------------------------------------------------------------------------
oauth2client                       7      0      0      0   100%
oauth2client._helpers             27      0      6      0   100%
oauth2client._openssl_crypt       41      0      4      0   100%
oauth2client._pycrypto_crypt      40      0      4      0   100%
oauth2client.appengine           337     29     87     20    88%   53-54, 233, 238, 271, 301, 303, 306-307, 314, 347, 362, 378, 382-383, 413, 437, 716-718, 733-734, 758, 800-801, 866, 929, 977, 1016
oauth2client.client              725     82    207     43    87%   57-58, 164, 206, 215, 224, 232, 292-296, 355, 365, 372, 724, 776, 889, 892-894, 931-932, 1221, 1237, 1258, 1345, 1418-1422, 1489-1491, 1495-1497, 1551, 1572, 1701, 1875-1896, 1999-2004, 2007, 2017, 2029-2067, 2093, 2095, 2098, 2113, 2222, 2227-2233
oauth2client.clientsecrets        49      0     18      0   100%
oauth2client.crypt                87     14     28      6    83%   44-49, 54-56, 62-66, 153, 167
oauth2client.util                 55      6     18      6    84%   138-141, 148-149, 220
oauth2client.xsrfutil             43      0     10      0   100%
--------------------------------------------------------------------------
TOTAL                           1411    131    382     75    89%
----------------------------------------------------------------------
Ran 35 tests in 0.373s

OK
__________________________________________________________________________ summary ___________________________________________________________________________
  cover: commands succeeded
  congratulations :)
```

Running `coverage report` shows that the coverage is actually combined between the two runs:

```
Name                           Stmts   Miss Branch BrMiss  Cover
----------------------------------------------------------------
oauth2client/__init__              7      0      0      0   100%
oauth2client/_helpers             27      0      6      0   100%
oauth2client/_openssl_crypt       41      0      4      0   100%
oauth2client/_pycrypto_crypt      40      0      4      0   100%
oauth2client/appengine           337     29     87     20    88%
oauth2client/client              725     82    207     43    87%
oauth2client/clientsecrets        49      0     18      0   100%
oauth2client/crypt                87     14     28      6    83%
oauth2client/devshell             53      0      8      0   100%
oauth2client/django_orm           68     26     22     14    56%
oauth2client/file                 47      0      4      0   100%
oauth2client/flask_util          167      0     40      0   100%
oauth2client/gce                  39      0      4      0   100%
oauth2client/keyring_storage      29      0      2      0   100%
oauth2client/locked_file         183    101     64     47    40%
oauth2client/multistore_file     165     17     24      7    87%
oauth2client/old_run              77     70     16     16     8%
oauth2client/service_account      54      0      0      0   100%
oauth2client/tools               109     65     18     16    36%
oauth2client/util                 55      6     18      6    84%
oauth2client/xsrfutil             43      0     10      0   100%
----------------------------------------------------------------
TOTAL                           2402    410    584    175    80%
```

Coveralls should pick up the combined coverage.

This removes nosexcover as well.
