### PR TITLE
Adding tests to coverage report.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ commands =
     nosetests \
       --with-coverage \
       --cover-package=oauth2client \
+      --cover-package=tests \
       --cover-erase \
       --cover-tests \
       --cover-branches \
@@ -29,6 +30,7 @@ commands =
     nosetests \
       --with-coverage \
       --cover-package=oauth2client.appengine \
+      --cover-package=tests.test_appengine \
       --with-gae \
       --cover-tests \
       --cover-branches \


### PR DESCRIPTION
This reveals there are dead lines in many of our tests. Some are innocuous, like

https://github.com/google/oauth2client/blob/f15e80ee5a4ff07803113204f6b8eda9be65f758/tests/test_xsrfutil.py#L296
https://github.com/google/oauth2client/blob/f15e80ee5a4ff07803113204f6b8eda9be65f758/tests/test_tools.py#L31

while others are caused by using `self.fail()` statements which never occur:

https://github.com/google/oauth2client/blob/f15e80ee5a4ff07803113204f6b8eda9be65f758/tests/test_service_account.py#L66
https://github.com/google/oauth2client/blob/f15e80ee5a4ff07803113204f6b8eda9be65f758/tests/test_service_account.py#L72

---

At `HEAD` right now, `tox -e cover` gets line coverage on

```
oauth2client/_helpers
oauth2client/_openssl_crypt
oauth2client/_pycrypto_crypt
oauth2client/appengine
oauth2client/client
oauth2client/clientsecrets
oauth2client/crypt
oauth2client/devshell
oauth2client/django_orm
oauth2client/file
oauth2client/flask_util
oauth2client/gce
oauth2client/keyring_storage
oauth2client/locked_file
oauth2client/multistore_file
oauth2client/service_account
oauth2client/tools
oauth2client/util
oauth2client/xsrfutil
```

With this PR, the following files also get line coverage (this is the point of `--cover-tests` BTW):

```
tests/__init__
tests/http_mock
tests/test__helpers
tests/test__pycrypto_crypt
tests/test_appengine
tests/test_client
tests/test_clientsecrets
tests/test_crypt
tests/test_devshell
tests/test_django_orm
tests/test_file
tests/test_flask_util
tests/test_gce
tests/test_jwt
tests/test_keyring_storage
tests/test_service_account
tests/test_tools
tests/test_util
tests/test_xsrfutil
```
