### PR TITLE
Adding no-cover pragmas to unittest.main().

### DIFF
--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -115,3 +115,7 @@ class Test__urlsafe_b64decode(unittest.TestCase):
         bad_string = b'+'
         self.assertRaises((TypeError, binascii.Error),
                           _urlsafe_b64decode, bad_string)
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest.main()

--- a/tests/test__pycrypto_crypt.py
+++ b/tests/test__pycrypto_crypt.py
@@ -61,3 +61,7 @@ class TestPyCryptoVerifier(unittest.TestCase):
         public_key = public_key.decode('utf-8')
         verifier = PyCryptoVerifier.from_string(public_key, is_x509_cert=True)
         self.assertTrue(isinstance(verifier, PyCryptoVerifier))
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest.main()

--- a/tests/test_appengine.py
+++ b/tests/test_appengine.py
@@ -880,5 +880,5 @@ class DecoratorXsrfProtectionTests(unittest.TestCase):
                           appengine._parse_state_value, state[1:], UserMock())
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1379,5 +1379,5 @@ class Test__save_private_file(unittest.TestCase):
         self._save_helper(filename)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()

--- a/tests/test_clientsecrets.py
+++ b/tests/test_clientsecrets.py
@@ -293,5 +293,5 @@ class CachedClientsecretsTests(unittest.TestCase):
         self.assertEqual('foo_client_secret', client_info['client_secret'])
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()

--- a/tests/test_crypt.py
+++ b/tests/test_crypt.py
@@ -315,3 +315,7 @@ class Test_verify_signed_jwt_with_certs(unittest.TestCase):
         verify_time.assert_called_once_with(payload_dict)
         check_aud.assert_called_once_with(payload_dict, audience)
         certs.values.assert_called_once_with()
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest.main()

--- a/tests/test_devshell.py
+++ b/tests/test_devshell.py
@@ -244,3 +244,7 @@ class DevshellCredentialsTests(unittest.TestCase):
             credentials = DevshellCredentials()
             self.assertRaises(NotImplementedError, getattr,
                               credentials, 'serialization_data')
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest.main()

--- a/tests/test_django_orm.py
+++ b/tests/test_django_orm.py
@@ -88,5 +88,5 @@ class TestFlowField(unittest.TestCase):
         self.assertEqual(prep_value, self.pickle)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -415,5 +415,5 @@ class OAuth2ClientFileTests(unittest.TestCase):
         self.assertEquals([], keys)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()

--- a/tests/test_flask_util.py
+++ b/tests/test_flask_util.py
@@ -426,5 +426,6 @@ class FlaskOAuth2Tests(unittest.TestCase):
 
             self.assertFalse('google_oauth2_credentials' in flask.session)
 
-if __name__ == '__main__':
+
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -172,3 +172,7 @@ class AppAssertionCredentialsTests(unittest.TestCase):
                               credentials)
         finally:
             os.path.isdir = ORIGINAL_ISDIR
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest.main()

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -337,5 +337,5 @@ class TestHasOpenSSLFlag(unittest.TestCase):
         self.assertEqual(True, HAS_CRYPTO)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()

--- a/tests/test_keyring_storage.py
+++ b/tests/test_keyring_storage.py
@@ -172,3 +172,7 @@ class _FakeLock(object):
 
     def release(self):
         self._release_count += 1
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest.main()

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -129,3 +129,7 @@ class ServiceAccountCredentialsTests(unittest.TestCase):
         self.assertFalse(self.credentials.access_token_expired)
         self.assertEqual(token_response_second,
                          self.credentials.token_response)
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -27,5 +27,5 @@ class TestClientRedirectServer(unittest.TestCase):
         self.assertEqual(httpd.query_params.get('code'), code)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -58,3 +58,7 @@ class KeyConversionTests(unittest.TestCase):
 
         # check we get the original dictionary back
         self.assertEqual(d, dict(tuple_key))
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest.main()

--- a/tests/test_xsrfutil.py
+++ b/tests/test_xsrfutil.py
@@ -292,5 +292,5 @@ class XsrfUtilTests(unittest.TestCase):
                                                  action_id=TEST_ACTION_ID_1))
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()


### PR DESCRIPTION
This is so we get 100% line coverage in our tests. Also
adding unittest.main() lines to the files missing it:

```
test__helpers.py
test__pycrypto_crypt.py
test_crypt.py
test_devshell.py
test_gce.py
test_keyring_storage.py
test_service_account.py
test_util.py
```
