### PR TITLE
Add HttpAccessTokenRefreshError

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -134,6 +134,13 @@ class AccessTokenRefreshError(Error):
     """Error trying to refresh an expired access token."""
 
 
+class HttpAccessTokenRefreshError(AccessTokenRefreshError):
+    """Error (with HTTP status) trying to refresh an expired access token."""
+    def __init__(self, *args, **kwargs):
+        super(HttpAccessTokenRefreshError, self).__init__(*args)
+        self.status = kwargs.get('status')
+
+
 class TokenRevokeError(Error):
     """Error trying to revoke a token."""
 
@@ -830,7 +837,7 @@ class OAuth2Credentials(Credentials):
                           refresh request.
 
         Raises:
-            AccessTokenRefreshError: When the refresh fails.
+            HttpAccessTokenRefreshError: When the refresh fails.
         """
         if not self.store:
             self._do_refresh_request(http_request)
@@ -858,7 +865,7 @@ class OAuth2Credentials(Credentials):
                           refresh request.
 
         Raises:
-            AccessTokenRefreshError: When the refresh fails.
+            HttpAccessTokenRefreshError: When the refresh fails.
         """
         body = self._generate_refresh_request_body()
         headers = self._generate_refresh_request_headers()
@@ -898,7 +905,7 @@ class OAuth2Credentials(Credentials):
                         self.store.locked_put(self)
             except (TypeError, ValueError):
                 pass
-            raise AccessTokenRefreshError(error_msg)
+            raise HttpAccessTokenRefreshError(error_msg, status=resp.status)
 
     def _revoke(self, http_request):
         """Revokes this credential and deletes the stored copy (if it exists).

--- a/oauth2client/gce.py
+++ b/oauth2client/gce.py
@@ -23,7 +23,7 @@ from six.moves import urllib
 
 from oauth2client._helpers import _from_bytes
 from oauth2client import util
-from oauth2client.client import AccessTokenRefreshError
+from oauth2client.client import HttpAccessTokenRefreshError
 from oauth2client.client import AssertionCredentials
 
 
@@ -80,7 +80,7 @@ class AppAssertionCredentials(AssertionCredentials):
                           the refresh request.
 
         Raises:
-            AccessTokenRefreshError: When the refresh fails.
+            HttpAccessTokenRefreshError: When the refresh fails.
         """
         query = '?scope=%s' % urllib.parse.quote(self.scope, '')
         uri = META.replace('{?scope}', query)
@@ -90,13 +90,14 @@ class AppAssertionCredentials(AssertionCredentials):
             try:
                 d = json.loads(content)
             except Exception as e:
-                raise AccessTokenRefreshError(str(e))
+                raise HttpAccessTokenRefreshError(str(e),
+                                                  status=response.status)
             self.access_token = d['accessToken']
         else:
             if response.status == 404:
                 content += (' This can occur if a VM was created'
                             ' with no service account or scopes.')
-            raise AccessTokenRefreshError(content)
+            raise HttpAccessTokenRefreshError(content, status=response.status)
 
     @property
     def serialization_data(self):


### PR DESCRIPTION
This adds an exception class including the HTTP status for access
token refresh requests made over HTTP.

Fixes https://github.com/google/oauth2client/issues/309
