### PR TITLE
Fix App Engine test branch miss.

### DIFF
--- a/tests/test_appengine.py
+++ b/tests/test_appengine.py
@@ -497,9 +497,9 @@ class DecoratorTests(unittest.TestCase):
         class TestRequiredHandler(webapp2.RequestHandler):
             @decorator.oauth_required
             def get(self):
-                if decorator.has_credentials():
-                    parent.had_credentials = True
-                    parent.found_credentials = decorator.credentials
+                parent.assertTrue(decorator.has_credentials())
+                parent.had_credentials = True
+                parent.found_credentials = decorator.credentials
                 if parent.should_raise:
                     raise Exception('')
 


### PR DESCRIPTION
In an App Engine / `webapp2.RequestHandler` method that has been decorated with `@decorator.oauth_required`, a redirect will occur if `decorator.has_credentials()` is `False`, so the branch `if decorator.has_credentials()` always occurs and the other one (the `False` state of that branch) never will.
