### PR TITLE
Isolate the Django ORM test from App Engine.

### DIFF
--- a/tests/test_django_orm.py
+++ b/tests/test_django_orm.py
@@ -26,13 +26,6 @@ import pickle
 import sys
 import unittest
 
-# Ensure that if app engine is available, we use the correct django from it
-try:
-    from google.appengine.dist import use_library
-    use_library('django', '1.5')
-except ImportError:
-    pass
-
 from oauth2client.client import Credentials
 from oauth2client.client import Flow
 


### PR DESCRIPTION
Since most of our tests run with `--ignore-files=test_appengine\.py`, the App Engine SDK is "never" available when this test runs in our set-up.
