### PR TITLE
Adding no-cover pragma to test_file for Py3 compat imports.

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -41,7 +41,7 @@ from six.moves import http_client
 try:
     # Python2
     from future_builtins import oct
-except:
+except:  # pragma: NO COVER
     pass
 
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'


### PR DESCRIPTION
The import always succeeds in Python 2.7, which is the only version where coverage reports are generated.

PS @nathanielmanistaatgoogle I [misspoke](https://github.com/google/oauth2client/pull/313#issuecomment-142352437) before. **NOW** the only line coverage [missing in tests](https://github.com/google/oauth2client/pull/297#issuecomment-142150899) are `self.fail()` lines.
