### PR TITLE
Avoid OAuth2Credentials id_token going out of sync after a token refresh.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -883,6 +883,10 @@ class OAuth2Credentials(Credentials):
                     seconds=int(d['expires_in'])) + datetime.datetime.utcnow()
             else:
                 self.token_expiry = None
+            if 'id_token' in d:
+                self.id_token = _extract_id_token(d['id_token'])
+            else:
+                self.id_token = None
             # On temporary refresh errors, the user does not actually have to
             # re-authorize, so we unflag here.
             self.invalid = False


### PR DESCRIPTION
After token refresh, `credential.id_token` no longer matches `_extract_id_token(credential.token_response['id_token'])`, as it does initially.  `access_token`, `token_expiry` are updated, but not `id_token`.

E.g., https://github.com/google/oauth2client/blob/master/oauth2client/client.py#L877 doesn't quite match https://github.com/google/oauth2client/blob/master/oauth2client/client.py#L2141
