### PR TITLE
Pinning tox to version 2.1.1.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@
 
 set -ev
 
-pip install tox
+pip install tox==2.1.1
 if [[ "${TOX_ENV}" == "pypy" ]]; then
     git clone https://github.com/yyuu/pyenv.git ${HOME}/.pyenv
     PYENV_ROOT="${HOME}/.pyenv"


### PR DESCRIPTION
This is a temporary workaround due to the config parsing
change introduced in 2.2.0.

See #339 for more details.
