### PR TITLE
Adding empty oauth2client.contrib

### DIFF
--- a/docs/source/oauth2client.contrib.rst
+++ b/docs/source/oauth2client.contrib.rst
@@ -1,0 +1,10 @@
+oauth2client.contrib package
+============================
+
+Module contents
+---------------
+
+.. automodule:: oauth2client.contrib
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/oauth2client.rst
+++ b/docs/source/oauth2client.rst
@@ -1,6 +1,13 @@
 oauth2client package
 ====================
 
+Subpackages
+-----------
+
+.. toctree::
+
+    oauth2client.contrib
+
 Submodules
 ----------
 

--- a/oauth2client/contrib/__init__.py
+++ b/oauth2client/contrib/__init__.py
@@ -1,0 +1,6 @@
+"""Contributed modules.
+
+Contrib contains modules that are not considered part of the core oauth2client
+library but provide additional functionality. These modules are intended to
+make it easier to use oauth2client.
+"""


### PR DESCRIPTION
Fixes #326, follow-up PRs will be submitted to move `flask_util`, `appengine`, and `django_orm`.
