### PR TITLE
[DO NOT MERGE] Re-write Storage

### DIFF
--- a/oauth2client/appengine.py
+++ b/oauth2client/appengine.py
@@ -464,7 +464,7 @@ class StorageByKeyName(Storage):
             db.delete(entity_key)
 
     @db.non_transactional(allow_existing=True)
-    def locked_get(self):
+    def get(self):
         """Retrieve Credential from datastore.
 
         Returns:
@@ -487,7 +487,7 @@ class StorageByKeyName(Storage):
         return credentials
 
     @db.non_transactional(allow_existing=True)
-    def locked_put(self, credentials):
+    def put(self, credentials):
         """Write a Credentials to the datastore.
 
         Args:
@@ -500,7 +500,7 @@ class StorageByKeyName(Storage):
             self._cache.set(self._key_name, credentials.to_json())
 
     @db.non_transactional(allow_existing=True)
-    def locked_delete(self):
+    def delete(self):
         """Delete Credential from datastore."""
 
         if self._cache:

--- a/oauth2client/django_orm.py
+++ b/oauth2client/django_orm.py
@@ -105,7 +105,7 @@ class FlowField(six.with_metaclass(models.SubfieldBase, models.Field)):
         return self.get_prep_value(value)
 
 
-class Storage(BaseStorage):
+class DjangoOrmStorage(BaseStorage):
     """Store and retrieve a single credential to and from the Django datastore.
 
     This Storage helper presumes the Credentials
@@ -129,7 +129,7 @@ class Storage(BaseStorage):
         self.key_value = key_value
         self.property_name = property_name
 
-    def locked_get(self):
+    def get(self):
         """Retrieve stored credential.
 
         Returns:
@@ -145,7 +145,7 @@ class Storage(BaseStorage):
                 credential.set_store(self)
         return credential
 
-    def locked_put(self, credentials, overwrite=False):
+    def put(self, credentials, overwrite=False):
         """Write a Credentials to the Django datastore.
 
         Args:
@@ -165,7 +165,7 @@ class Storage(BaseStorage):
         setattr(entity, self.property_name, credentials)
         entity.save()
 
-    def locked_delete(self):
+    def delete(self):
         """Delete Credentials from the datastore."""
 
         query = {self.key_name: self.key_value}

--- a/oauth2client/file_storage.py
+++ b/oauth2client/file_storage.py
@@ -19,7 +19,6 @@ credentials.
 """
 
 import os
-import threading
 
 from oauth2client.client import Credentials
 from oauth2client.client import Storage as BaseStorage
@@ -32,34 +31,18 @@ class CredentialsFileSymbolicLinkError(Exception):
     """Credentials files must not be symbolic links."""
 
 
-class Storage(BaseStorage):
+class FileStorage(BaseStorage):
     """Store and retrieve a single credential to and from a file."""
 
     def __init__(self, filename):
         self._filename = filename
-        self._lock = threading.Lock()
 
     def _validate_file(self):
         if os.path.islink(self._filename):
             raise CredentialsFileSymbolicLinkError(
                 'File: %s is a symbolic link.' % self._filename)
 
-    def acquire_lock(self):
-        """Acquires any lock necessary to access this Storage.
-
-        This lock is not reentrant.
-        """
-        self._lock.acquire()
-
-    def release_lock(self):
-        """Release the Storage lock.
-
-        Trying to release a lock that isn't held will result in a
-        RuntimeError.
-        """
-        self._lock.release()
-
-    def locked_get(self):
+    def get(self):
         """Retrieve Credential from file.
 
         Returns:
@@ -98,7 +81,7 @@ class Storage(BaseStorage):
             finally:
                 os.umask(old_umask)
 
-    def locked_put(self, credentials):
+    def put(self, credentials):
         """Write Credentials to file.
 
         Args:
@@ -113,7 +96,7 @@ class Storage(BaseStorage):
         f.write(credentials.to_json())
         f.close()
 
-    def locked_delete(self):
+    def delete(self):
         """Delete Credentials file.
 
         Args:

--- a/oauth2client/flask_util.py
+++ b/oauth2client/flask_util.py
@@ -557,7 +557,7 @@ class FlaskSessionStorage(Storage):
     implementation.
     """
 
-    def locked_get(self):
+    def get(self):
         serialized = session.get(_CREDENTIALS_KEY)
 
         if serialized is None:
@@ -568,9 +568,9 @@ class FlaskSessionStorage(Storage):
 
         return credentials
 
-    def locked_put(self, credentials):
+    def put(self, credentials):
         session[_CREDENTIALS_KEY] = credentials.to_json()
 
-    def locked_delete(self):
+    def delete(self):
         if _CREDENTIALS_KEY in session:
             del session[_CREDENTIALS_KEY]

--- a/oauth2client/keyring_storage.py
+++ b/oauth2client/keyring_storage.py
@@ -28,7 +28,7 @@ from oauth2client.client import Storage as BaseStorage
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
 
-class Storage(BaseStorage):
+class KeyringStorage(BaseStorage):
     """Store and retrieve a single credential to and from the keyring.
 
     To use this module you must have the keyring module installed. See
@@ -61,24 +61,8 @@ class Storage(BaseStorage):
         """
         self._service_name = service_name
         self._user_name = user_name
-        self._lock = threading.Lock()
 
-    def acquire_lock(self):
-        """Acquires any lock necessary to access this Storage.
-
-        This lock is not reentrant.
-        """
-        self._lock.acquire()
-
-    def release_lock(self):
-        """Release the Storage lock.
-
-        Trying to release a lock that isn't held will result in a
-        RuntimeError.
-        """
-        self._lock.release()
-
-    def locked_get(self):
+    def get(self):
         """Retrieve Credential from file.
 
         Returns:
@@ -96,7 +80,7 @@ class Storage(BaseStorage):
 
         return credentials
 
-    def locked_put(self, credentials):
+    def put(self, credentials):
         """Write Credentials to file.
 
         Args:
@@ -105,7 +89,7 @@ class Storage(BaseStorage):
         keyring.set_password(self._service_name, self._user_name,
                              credentials.to_json())
 
-    def locked_delete(self):
+    def delete(self):
         """Delete Credentials file.
 
         Args:

--- a/oauth2client/locked_storage.py
+++ b/oauth2client/locked_storage.py
@@ -1,0 +1,48 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TODO"""
+
+import os
+import threading
+
+from oauth2client.client import Storage as Storage
+
+
+class LockedStorage(Storage):
+    """TODO"""
+
+    def __init__(self, storage, lock=None):
+        """TODO"""
+        self._storage = storage
+
+        if lock is None:
+            lock = threading.Lock()
+
+        self._lock = lock
+
+    def get(self, *args, **kwargs):
+        """TODO"""
+        with self._lock:
+            return self._storage.get(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """TODO"""
+        with self._lock:
+            return self._storage.delete(*args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        """TODO"""
+        with self._lock:
+            return self._storage.put(*args, **kwargs)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -593,7 +593,7 @@ class GoogleCredentialsTests(unittest.TestCase):
 class DummyDeleteStorage(Storage):
     delete_called = False
 
-    def locked_delete(self):
+    def delete(self):
         self.delete_called = True
 
 

--- a/tests/test_django_orm.py
+++ b/tests/test_django_orm.py
@@ -42,7 +42,7 @@ from oauth2client.client import Flow
 from oauth2client.client import OAuth2Credentials
 from oauth2client.django_orm import CredentialsField
 from oauth2client.django_orm import FlowField
-from oauth2client.django_orm import Storage
+from oauth2client.django_orm import DjangoOrmStorage
 from oauth2client import GOOGLE_TOKEN_URI
 
 __author__ = 'conleyo@google.com (Conley Owens)'
@@ -119,7 +119,7 @@ class TestFlowField(unittest.TestCase):
         self.assertEqual(value_str, None)
 
 
-class TestStorage(unittest.TestCase):
+class TestDjangoOrmStorage(unittest.TestCase):
 
     def setUp(self):
         access_token = 'foo'
@@ -137,7 +137,7 @@ class TestStorage(unittest.TestCase):
         key_name = 'foo'
         key_value = 'bar'
         property_name = 'credentials'
-        storage = Storage(FakeCredentialsModel, key_name,
+        storage = DjangoOrmStorage(FakeCredentialsModel, key_name,
                           key_value, property_name)
 
         self.assertEqual(storage.model_class, FakeCredentialsModel)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -31,7 +31,7 @@ import unittest
 from .http_mock import HttpMockSequence
 import six
 
-from oauth2client import file
+from oauth2client import file_storage
 from oauth2client import locked_file
 from oauth2client import multistore_file
 from oauth2client import util
@@ -79,7 +79,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
         return credentials
 
     def test_non_existent_file_storage(self):
-        s = file.Storage(FILENAME)
+        s = file_storage.FileStorage(FILENAME)
         credentials = s.get()
         self.assertEquals(None, credentials)
 
@@ -87,11 +87,11 @@ class OAuth2ClientFileTests(unittest.TestCase):
         if hasattr(os, 'symlink'):
             SYMFILENAME = FILENAME + '.sym'
             os.symlink(FILENAME, SYMFILENAME)
-            s = file.Storage(SYMFILENAME)
+            s = file_storage.FileStorage(SYMFILENAME)
             try:
                 s.get()
                 self.fail('Should have raised an exception.')
-            except file.CredentialsFileSymbolicLinkError:
+            except file_storage.CredentialsFileSymbolicLinkError:
                 pass
             finally:
                 os.unlink(SYMFILENAME)
@@ -106,7 +106,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
 
         # Storage should be not be able to read that object, as the capability
         # to read and write credentials as pickled objects has been removed.
-        s = file.Storage(FILENAME)
+        s = file_storage.FileStorage(FILENAME)
         read_credentials = s.get()
         self.assertEquals(None, read_credentials)
 
@@ -124,7 +124,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
                       datetime.timedelta(minutes=15))
         credentials = self.create_test_credentials(expiration=expiration)
 
-        s = file.Storage(FILENAME)
+        s = file_storage.FileStorage(FILENAME)
         s.put(credentials)
         credentials = s.get()
         new_cred = copy.copy(credentials)
@@ -147,7 +147,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
                       datetime.timedelta(minutes=15))
         credentials = self.create_test_credentials(expiration=expiration)
 
-        s = file.Storage(FILENAME)
+        s = file_storage.FileStorage(FILENAME)
         s.put(credentials)
         credentials = s.get()
         new_cred = copy.copy(credentials)
@@ -176,7 +176,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
                       datetime.timedelta(minutes=15))
         credentials = self.create_test_credentials(expiration=expiration)
 
-        s = file.Storage(FILENAME)
+        s = file_storage.FileStorage(FILENAME)
         s.put(credentials)
         credentials = s.get()
         new_cred = copy.copy(credentials)
@@ -191,7 +191,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
                       datetime.timedelta(minutes=15))
         credentials = self.create_test_credentials(expiration=expiration)
 
-        s = file.Storage(FILENAME)
+        s = file_storage.FileStorage(FILENAME)
         s.put(credentials)
         credentials = s.get()
         new_cred = copy.copy(credentials)
@@ -221,7 +221,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
     def test_credentials_delete(self):
         credentials = self.create_test_credentials()
 
-        s = file.Storage(FILENAME)
+        s = file_storage.FileStorage(FILENAME)
         s.put(credentials)
         credentials = s.get()
         self.assertNotEquals(None, credentials)
@@ -235,7 +235,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
 
         credentials = AccessTokenCredentials(access_token, user_agent)
 
-        s = file.Storage(FILENAME)
+        s = file_storage.FileStorage(FILENAME)
         credentials = s.put(credentials)
         credentials = s.get()
 
@@ -261,7 +261,7 @@ class OAuth2ClientFileTests(unittest.TestCase):
 
         store.put(credentials)
         if os.name == 'posix':
-            self.assertTrue(store._multistore._read_only)
+            self.assertTrue(store._storage._multistore._read_only)
         os.chmod(FILENAME, 0o600)
 
     def test_multistore_no_symbolic_link_files(self):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -32,7 +32,7 @@ from oauth2client.client import verify_id_token
 from oauth2client.client import HAS_OPENSSL
 from oauth2client.client import HAS_CRYPTO
 from oauth2client import crypt
-from oauth2client.file import Storage
+from oauth2client.file_storage import FileStorage as Storage
 
 
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'


### PR DESCRIPTION
This is a rough-cut to sanity check the concept. Docstrings and full tests still missing.

New:
- `client.Storage` is an abstract base class.
- `locked_storage.LockedStorage` provides locking based on context managers and defaults to `threading.Lock`.
- `locked_storage.threadsafe` is a class-level decorator to provide thread safety. This is applied to `FileStorage` and `KeyringStorage`.

Changed:
- All `Storage` subclasses have been updated to use the new base class.
- `file.Storage` renamed to `file_storage.FileStorage`.
- `keyring_storage.Storage` renamed to `keyring_storage.KeyringStorage`.
- `django_orm.Storage` renamed to `django_orm.DjangoOrmStorage`.

**Questionable changes**

As mentioned in [a comment on #344](https://github.com/google/oauth2client/pull/344#issuecomment-160785708), `Credentials` has the unfortunate behavior of using the Storage's lock to prevent concurrently refreshing the credentials. IMO, Refresh locking should be handled as a separate concern. For now, `Storage` implements a no-op `lock()`.
