### PR TITLE
More informative error when failing to open secrets file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,10 @@ Running Tests
     least version 2.6 of `pypy` installed. See the [docs][13] for
     more information.
 
+-   **Note** that `django` related tests are turned off for Python 2.6
+    and 3.3. This is because `django` dropped support for
+    [2.6 in `django==1.7`][14] and for [3.3 in `django==1.9`][15].
+
 Running System Tests
 --------------------
 
@@ -196,3 +200,5 @@ we'll be able to accept your pull requests.
 [11]: #include-tests
 [12]: #make-the-pull-request
 [13]: http://oauth2client.readthedocs.org/en/latest/#using-pypy
+[14]: https://docs.djangoproject.com/en/1.7/faq/install/#what-python-version-can-i-use-with-django
+[15]: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django

--- a/oauth2client/clientsecrets.py
+++ b/oauth2client/clientsecrets.py
@@ -121,8 +121,9 @@ def _loadfile(filename):
     try:
         with open(filename, 'r') as fp:
             obj = json.load(fp)
-    except IOError:
-        raise InvalidClientSecretsError('File not found: "%s"' % filename)
+    except IOError as exc:
+        raise InvalidClientSecretsError('Error opening file', exc.filename,
+                                        exc.strerror, exc.errno)
     return _validate_clientsecrets(obj)
 
 

--- a/tests/test_clientsecrets.py
+++ b/tests/test_clientsecrets.py
@@ -14,6 +14,7 @@
 
 """Unit tests for oauth2client.clientsecrets."""
 
+import errno
 from io import StringIO
 import os
 import tempfile
@@ -32,7 +33,8 @@ __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 VALID_FILE = os.path.join(DATA_DIR, 'client_secrets.json')
 INVALID_FILE = os.path.join(DATA_DIR, 'unfilled_client_secrets.json')
-NONEXISTENT_FILE = os.path.join(__file__, '..', 'afilethatisntthere.json')
+NONEXISTENT_FILE = os.path.join(
+    os.path.dirname(__file__), 'afilethatisntthere.json')
 
 
 class Test__validate_clientsecrets(unittest.TestCase):
@@ -222,12 +224,15 @@ class OAuth2CredentialsTests(unittest.TestCase):
             except clientsecrets.InvalidClientSecretsError as e:
                 self.assertTrue(str(e).startswith(match))
 
-    def test_load_by_filename(self):
+    def test_load_by_filename_missing_file(self):
+        caught_exception = None
         try:
             clientsecrets._loadfile(NONEXISTENT_FILE)
-            self.fail('should fail to load a missing client_secrets file.')
-        except clientsecrets.InvalidClientSecretsError as e:
-            self.assertTrue(str(e).startswith('File'))
+        except clientsecrets.InvalidClientSecretsError as exc:
+            caught_exception = exc
+
+        self.assertEquals(caught_exception.args[1], NONEXISTENT_FILE)
+        self.assertEquals(caught_exception.args[3], errno.ENOENT)
 
 
 class CachedClientsecretsTests(unittest.TestCase):

--- a/tests/test_django_orm.py
+++ b/tests/test_django_orm.py
@@ -26,16 +26,28 @@ import os
 import pickle
 import sys
 import unittest
-
 # Mock a Django environment
 from django.conf import global_settings
-global_settings.SECRET_KEY = 'NotASecret'
-os.environ['DJANGO_SETTINGS_MODULE'] = 'django_settings'
-sys.modules['django_settings'] = django_settings = imp.new_module(
-    'django_settings')
-django_settings.SECRET_KEY = 'xyzzy'
-from django.db import models
 
+os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_django_settings'
+from django.conf import settings
+
+settings.SECRET_KEY = 'this string is not a real Django SECRET_KEY'
+settings.INSTALLED_APPS = ['tests.test_django_orm']
+
+import django
+
+django.setup()
+from django.apps import AppConfig
+
+
+class DjangoOrmTestApp(AppConfig):
+    """App Config for Django Helper."""
+    name = 'oauth2client.tests.test_django_orm'
+    verbose_name = "Django Test App"
+
+
+from django.db import models
 from oauth2client._helpers import _from_bytes
 from oauth2client.client import Credentials
 from oauth2client.client import Flow

--- a/tests/test_django_settings.py
+++ b/tests/test_django_settings.py
@@ -1,0 +1,34 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+SECRET_KEY = 'this string is not a real django secret key'
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join('.', 'db.sqlite3'),
+    }
+}
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware'
+)
+
+ALLOWED_HOSTS = ['testserver']
+
+GOOGLE_OAUTH2_CLIENT_ID = 'client_id2'
+GOOGLE_OAUTH2_CLIENT_SECRET = 'hunter2'
+GOOGLE_OAUTH2_SCOPES = ('https://www.googleapis.com/auth/cloud-platform',)
+
+ROOT_URLCONF = 'tests.test_django_util'

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,28 @@ deps = {[testenv]deps}
     coverage
     nosegae
 
+[testenv:py26]
+basepython =
+    python2.6
+commands =
+    nosetests \
+      --ignore-files=test_appengine\.py \
+      --ignore-files=test_django_orm\.py \
+      --ignore-files=test_django_settings\.py \
+      {posargs}
+deps = {[testenv]basedeps}
+
+[testenv:py33]
+basepython =
+    python3.3
+commands =
+    nosetests \
+      --ignore-files=test_appengine\.py \
+      --ignore-files=test_django_orm\.py \
+      --ignore-files=test_django_settings\.py \
+      {posargs}
+deps = {[testenv]basedeps}
+
 [testenv:cover]
 basepython = {[coverbase]basepython}
 commands =
@@ -71,11 +93,6 @@ deps =
     sphinx-rtd-theme
     webapp2
 commands = {toxinidir}/scripts/build-docs
-
-[testenv:py26]
-basepython = python2.6
-deps = {[testenv]basedeps}
-       django>=1.5,<1.6
 
 [testenv:gae]
 basepython = python2.7


### PR DESCRIPTION
Django 1.9 should work so py27 should work at least.

Fixes #348.
