### PR TITLE
Improved unit-test line coverage and quality.

### DIFF
--- a/tests/contrib/test_multistore_file.py
+++ b/tests/contrib/test_multistore_file.py
@@ -1,3 +1,17 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for oauth2client.multistore_file."""
 
 import datetime

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2.4
-#
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Oauth2client tests
-
-Unit tests for oauth2client.
-"""
+"""Unit tests for JWT related methods in oauth2client."""
 
 import os
 import tempfile
 import time
-import unittest
+import unittest2
 
 from .http_mock import HttpMockSequence
 from oauth2client.client import Credentials
@@ -45,7 +40,7 @@ def datafile(filename):
     return data
 
 
-class CryptTests(unittest.TestCase):
+class CryptTests(unittest2.TestCase):
 
     def setUp(self):
         self.format = 'p12'
@@ -83,11 +78,11 @@ class CryptTests(unittest.TestCase):
         certs = {'foo': public_key}
         audience = ('https://www.googleapis.com/auth/id?client_id='
                     'external_public_key@testing.gserviceaccount.com')
-        try:
+
+        with self.assertRaises(crypt.AppIdentityError) as exc_manager:
             crypt.verify_signed_jwt_with_certs(jwt, certs, audience)
-            self.fail()
-        except crypt.AppIdentityError as e:
-            self.assertTrue(expected_error in str(e))
+
+        self.assertTrue(expected_error in str(exc_manager.exception))
 
     def _create_signed_jwt(self):
         private_key = datafile('privatekey.%s' % self.format)
@@ -216,7 +211,7 @@ class PEMCryptTestsOpenSSL(CryptTests):
         self.verifier = crypt.OpenSSLVerifier
 
 
-class SignedJwtAssertionCredentialsTests(unittest.TestCase):
+class SignedJwtAssertionCredentialsTests(unittest2.TestCase):
 
     def setUp(self):
         self.format = 'p12'
@@ -310,7 +305,7 @@ class PEMSignedJwtAssertionCredentialsPyCryptoTests(
         crypt.Signer = crypt.PyCryptoSigner
 
 
-class PKCSSignedJwtAssertionCredentialsPyCryptoTests(unittest.TestCase):
+class PKCSSignedJwtAssertionCredentialsPyCryptoTests(unittest2.TestCase):
 
     def test_for_failure(self):
         crypt.Signer = crypt.PyCryptoSigner
@@ -320,14 +315,12 @@ class PKCSSignedJwtAssertionCredentialsPyCryptoTests(unittest.TestCase):
             private_key,
             scope='read+write',
             sub='joe@example.org')
-        try:
-            credentials._generate_assertion()
-            self.fail()
-        except NotImplementedError:
-            pass
+
+        self.assertRaises(NotImplementedError,
+                          credentials._generate_assertion)
 
 
-class TestHasOpenSSLFlag(unittest.TestCase):
+class TestHasOpenSSLFlag(unittest2.TestCase):
 
     def test_true(self):
         self.assertEqual(True, HAS_OPENSSL)
@@ -335,4 +328,4 @@ class TestHasOpenSSLFlag(unittest.TestCase):
 
 
 if __name__ == '__main__':  # pragma: NO COVER
-    unittest.main()
+    unittest2.main()

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2.4
-#
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,17 +59,11 @@ class ServiceAccountCredentialsTests(unittest.TestCase):
 
         self.assertTrue(rsa.pkcs1.verify(b'Google', signature, pub_key))
 
-        try:
-            rsa.pkcs1.verify(b'Orest', signature, pub_key)
-            self.fail('Verification should have failed!')
-        except rsa.pkcs1.VerificationError:
-            pass  # Expected
-
-        try:
-            rsa.pkcs1.verify(b'Google', b'bad signature', pub_key)
-            self.fail('Verification should have failed!')
-        except rsa.pkcs1.VerificationError:
-            pass  # Expected
+        self.assertRaises(rsa.pkcs1.VerificationError,
+                          rsa.pkcs1.verify, b'Orest', signature, pub_key)
+        self.assertRaises(rsa.pkcs1.VerificationError,
+                          rsa.pkcs1.verify,
+                          b'Google', b'bad signature', pub_key)
 
     def test_service_account_email(self):
         self.assertEqual(self.service_account_email,

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ basedeps = keyring
            webtest
            nose
            flask
+           unittest2
 deps = {[testenv]basedeps}
        django
 setenv =


### PR DESCRIPTION
In particular
- Upgraded some unit test modules to `unittest2`.
- Got to 100% line coverage in `test_jwt`, `test_clientsecrets`,
  and `test_service_account` by using `self.assertRaises`
  instead of `self.fail()`
- In some places used `self.assertRaises` as a context manager so
  the thrown exception can be inspected / compared against. This
  is done instead of manually catching the exception and
  holding on to it (`unittest2` backports this feature from
  `unittest` that was not available in Python 2.6)
- Added license to `test_multistore_file`
- Removed legacy `python2.4` hashbang from `test_jwt` and
  `test_service_account`
- Added `unittest2` as a test dependency in `tox.ini`
- Updated `test_clientsecrets.test_load_by_filename_missing_file`
  to use the `self.assertRaises` context manager (this was
  a problem in #349 and #350)
- Updated `test_jwt` module docstring to reflect actual purpose
