### PR TITLE
Unpinning tox version in install script.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@
 
 set -ev
 
-pip install tox==2.1.1
+pip install tox
 if [[ "${TOX_ENV}" == "pypy" ]]; then
     git clone https://github.com/yyuu/pyenv.git ${HOME}/.pyenv
     PYENV_ROOT="${HOME}/.pyenv"


### PR DESCRIPTION
Regressions from tox 2.2.0 were fixed in >=2.3.
