### PR TITLE
Minor changes to install script files to ensure contrib module is accessable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include contrib/ **

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ from setuptools import setup
 
 packages = [
     'oauth2client',
+    'oauth2client.contrib',
+    'oauth2client.contrib.django_util'
 ]
 
 install_requires = [


### PR DESCRIPTION
Docs at http://oauth2client.readthedocs.org/en/latest/source/oauth2client.contrib.html indicate that oauth2 client utility scripts for things like flask should be accessed at oauth2client.contrib .
Current setup.py and manifest.in is not setup for this and yeilds an install of the oauth2client module that does not include access to things like flask_util. 

This problem is made worse by the fact that this problem has been pushed to pypy, so a fresh pip install will prevent access to flask_util et al. 
