### PR TITLE
Factor out usage of utcnow() in client.

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,12 +21,12 @@ Unit tests for oauth2client.
 
 import base64
 import contextlib
+import copy
 import datetime
 import json
 import os
 import socket
 import sys
-import time
 
 import mock
 import six
@@ -841,11 +841,27 @@ class BasicCredentialsTests(unittest2.TestCase):
         instance = OAuth2Credentials.from_json(self.credentials.to_json())
         self.assertEqual('foobar', instance.token_response)
 
-    def test_get_access_token(self):
-        S = 2  # number of seconds in which the token expires
-        token_response_first = {'access_token': 'first_token', 'expires_in': S}
-        token_response_second = {'access_token': 'second_token',
-                                 'expires_in': S}
+    @mock.patch('oauth2client.client._UTCNOW')
+    def test_get_access_token(self, utcnow):
+        # Configure the patch.
+        seconds = 11
+        NOW = datetime.datetime(1992, 12, 31, second=seconds)
+        utcnow.return_value = NOW
+
+        lifetime = 2  # number of seconds in which the token expires
+        EXPIRY_TIME = datetime.datetime(1992, 12, 31,
+                                        second=seconds + lifetime)
+
+        token1 = u'first_token'
+        token_response_first = {
+            'access_token': token1,
+            'expires_in': lifetime,
+        }
+        token2 = u'second_token'
+        token_response_second = {
+            'access_token': token2,
+            'expires_in': lifetime,
+        }
         http = HttpMockSequence([
             ({'status': '200'}, json.dumps(token_response_first).encode(
                 'utf-8')),
@@ -853,27 +869,61 @@ class BasicCredentialsTests(unittest2.TestCase):
                 'utf-8')),
         ])
 
-        token = self.credentials.get_access_token(http=http)
-        self.assertEqual('first_token', token.access_token)
-        self.assertEqual(S - 1, token.expires_in)
-        self.assertFalse(self.credentials.access_token_expired)
-        self.assertEqual(token_response_first, self.credentials.token_response)
+        # Use the current credentials but unset the expiry and
+        # the access token.
+        credentials = copy.deepcopy(self.credentials)
+        credentials.access_token = None
+        credentials.token_expiry = None
 
-        token = self.credentials.get_access_token(http=http)
-        self.assertEqual('first_token', token.access_token)
-        self.assertEqual(S - 1, token.expires_in)
-        self.assertFalse(self.credentials.access_token_expired)
-        self.assertEqual(token_response_first, self.credentials.token_response)
+        # Get Access Token, First attempt.
+        self.assertEqual(credentials.access_token, None)
+        self.assertFalse(credentials.access_token_expired)
+        self.assertEqual(credentials.token_expiry, None)
+        token = credentials.get_access_token(http=http)
+        self.assertEqual(credentials.token_expiry, EXPIRY_TIME)
+        self.assertEqual(token1, token.access_token)
+        self.assertEqual(lifetime, token.expires_in)
+        self.assertEqual(token_response_first, credentials.token_response)
+        # Two utcnow calls are expected:
+        # - get_access_token() -> _do_refresh_request (setting expires in)
+        # - get_access_token() -> _expires_in()
+        expected_utcnow_calls = [mock.call()] * 2
+        self.assertEqual(expected_utcnow_calls, utcnow.mock_calls)
 
-        time.sleep(S + 0.5)  # some margin to avoid flakiness
-        self.assertTrue(self.credentials.access_token_expired)
+        # Get Access Token, Second Attempt (not expired)
+        self.assertEqual(credentials.access_token, token1)
+        self.assertFalse(credentials.access_token_expired)
+        token = credentials.get_access_token(http=http)
+        # Make sure no refresh occurred since the token was not expired.
+        self.assertEqual(token1, token.access_token)
+        self.assertEqual(lifetime, token.expires_in)
+        self.assertEqual(token_response_first, credentials.token_response)
+        # Three more utcnow calls are expected:
+        # - access_token_expired
+        # - get_access_token() -> access_token_expired
+        # - get_access_token -> _expires_in
+        expected_utcnow_calls = [mock.call()] * (2 + 3)
+        self.assertEqual(expected_utcnow_calls, utcnow.mock_calls)
 
-        token = self.credentials.get_access_token(http=http)
-        self.assertEqual('second_token', token.access_token)
-        self.assertEqual(S - 1, token.expires_in)
-        self.assertFalse(self.credentials.access_token_expired)
+        # Get Access Token, Third Attempt (force expiration)
+        self.assertEqual(credentials.access_token, token1)
+        credentials.token_expiry = NOW  # Manually force expiry.
+        self.assertTrue(credentials.access_token_expired)
+        token = credentials.get_access_token(http=http)
+        # Make sure refresh occurred since the token was not expired.
+        self.assertEqual(token2, token.access_token)
+        self.assertEqual(lifetime, token.expires_in)
+        self.assertFalse(credentials.access_token_expired)
         self.assertEqual(token_response_second,
-                         self.credentials.token_response)
+                         credentials.token_response)
+        # Five more utcnow calls are expected:
+        # - access_token_expired
+        # - get_access_token -> access_token_expired
+        # - get_access_token -> _do_refresh_request
+        # - get_access_token -> _expires_in
+        # - access_token_expired
+        expected_utcnow_calls = [mock.call()] * (2 + 3 + 5)
+        self.assertEqual(expected_utcnow_calls, utcnow.mock_calls)
 
     def test_has_scopes(self):
         self.assertTrue(self.credentials.has_scopes('foo'))


### PR DESCRIPTION
This is to enable better stubs in testing and eliminate two `sleep()` statements in unit tests. (The philosophy is "unit tests should be fast".)

Towards #357.
