### PR TITLE
Removing keyring testing from py26 testing.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist = py26,py27,py33,py34,pypy,gae,cover
 
 [testenv]
-basedeps = keyring
-           mock>=1.3.0
+basedeps = mock>=1.3.0
            pycrypto>=2.6
            cryptography>=1.0
            pyopenssl>=0.14
@@ -13,6 +12,7 @@ basedeps = keyring
            unittest2
 deps = {[testenv]basedeps}
        django
+       keyring
 setenv =
     pypy: with_gmp=no
     DJANGO_SETTINGS_MODULE=tests.contrib.test_django_settings
@@ -53,6 +53,7 @@ commands =
       --ignore-files=test_django_orm\.py \
       --ignore-files=test_django_settings\.py \
       --ignore-files=test_django_util\.py \
+      --ignore-files=test_keyring_storage\.py \
       --exclude-dir=oauth2client/contrib/django_util \
       {posargs}
 deps = {[testenv]basedeps}
@@ -70,6 +71,7 @@ commands =
       --exclude-dir=oauth2client/contrib/django_util \
       {posargs}
 deps = {[testenv]basedeps}
+       keyring
        nose-exclude
 
 [testenv:cover]


### PR DESCRIPTION
With the `6.0` release on January 5, 2016, the `keyring` package no longer supports Python 2.6 (it won't even install).

@nathanielmanistaatgoogle This was discovered in #376.
