### PR TITLE
Fall back to read-only credentials on EACCES errors

### DIFF
--- a/oauth2client/contrib/multistore_file.py
+++ b/oauth2client/contrib/multistore_file.py
@@ -293,6 +293,8 @@ class _MultiStore(object):
             elif e.errno == errno.EDEADLK:
                 logger.warn('Lock contention on multistore file, opening '
                             'in read-only mode.')
+            elif e.errno == errno.EACCES:
+                logger.warn('Cannot access credentials file.')
             else:
                 raise
         if not self._file.is_locked():

--- a/tests/contrib/test_multistore_file.py
+++ b/tests/contrib/test_multistore_file.py
@@ -82,7 +82,8 @@ class MultistoreFileTests(unittest.TestCase):
         os.close(filehandle)
 
         try:
-            for error_code in (errno.EDEADLK, errno.ENOSYS, errno.ENOLCK):
+            for error_code in (errno.EDEADLK, errno.ENOSYS, errno.ENOLCK,
+                               errno.EACCES):
                 multistore = multistore_file._MultiStore(filename)
                 multistore._file = _MockLockedFile(filename, error_code)
                 # Should not raise even though the underlying file class did.


### PR DESCRIPTION
This change fixes a bug where multiple threads and/or processes
using multistore_file on Windows to access the same backing
store could raise IOError errno.EACCES to the calling application.
This change causes a fallback to read only mode and refreshes
credentials if necessary.

Fixes #386
