### PR TITLE
Cosmetic tweaks

### DIFF
--- a/oauth2client/contrib/xsrfutil.py
+++ b/oauth2client/contrib/xsrfutil.py
@@ -1,4 +1,3 @@
-#
 # Copyright 2014 the Melange authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oauth2client/util.py
+++ b/oauth2client/util.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 """Common utility library."""
 

--- a/tests/contrib/test_appengine.py
+++ b/tests/contrib/test_appengine.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2.4
-#
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/contrib/test_django_orm.py
+++ b/tests/contrib/test_django_orm.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2.4
-#
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/contrib/test_xsrfutil.py
+++ b/tests/contrib/test_xsrfutil.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for oauth2client.contrib.xsrfutil.
 
-Unit tests for oauth2client.contrib.xsrfutil.
-"""
+"""Tests for oauth2client.contrib.xsrfutil."""
 
 import base64
 import unittest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2.4
-#
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2.4
-#
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Unnecessary (and embarrassingly out-of-date) shebang lines are dropped.
License headers are trimmed to not have single-octothorpe lines above
or below. The xsrfutil_test module doc string is trimmed of repeated
information and placed properly after a blank line following the
license header.

I expect this to take all of five seconds to review. :-P
