### PR TITLE
Use symbolic constant rather than literal value

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,14 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test Package set up."""
+"""Test package set-up."""
 
-import oauth2client.util
-
+from oauth2client import util
 
 __author__ = 'afshar@google.com (Ali Afshar)'
 
 
 def setup_package():
     """Run on testing package."""
-    oauth2client.util.positional_parameters_enforcement = 'EXCEPTION'
+    util.positional_parameters_enforcement = util.POSITIONAL_EXCEPTION


### PR DESCRIPTION
This cost me a few minutes of debugging because I was looking for use of the symbolic constant and it never occurred to me to look for use of the literal string value.

Another reason to get excited about using [`enum`](https://pypi.python.org/pypi/enum34) for enumerated types!
