### PR TITLE
Helpful error message in P12 factory in absence of pyOpenSSL.

### DIFF
--- a/oauth2client/_pycrypto_crypt.py
+++ b/oauth2client/_pycrypto_crypt.py
@@ -120,9 +120,7 @@ class PyCryptoSigner(object):
             pkey = RSA.importKey(parsed_pem_key)
         else:
             raise NotImplementedError(
-                'PKCS12 format is not supported by the PyCrypto library. '
-                'Try converting to a "PEM" '
-                '(openssl pkcs12 -in xxxxx.p12 -nodes -nocerts > '
-                'privatekey.pem) '
-                'or using PyOpenSSL if native code is an option.')
+                'No key in PEM format was detected. This implementation '
+                'can only use the PyCrypto library for keys in PEM '
+                'format.')
         return PyCryptoSigner(pkey)

--- a/oauth2client/service_account.py
+++ b/oauth2client/service_account.py
@@ -240,6 +240,8 @@ class ServiceAccountCredentials(AssertionCredentials):
         """
         if private_key_password is None:
             private_key_password = _PASSWORD_DEFAULT
+        if crypt.Signer is not crypt.OpenSSLSigner:
+            raise NotImplementedError(_PKCS12_ERROR)
         signer = crypt.Signer.from_string(private_key_pkcs12,
                                           private_key_password)
         credentials = cls(service_account_email, signer, scopes=scopes)

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -165,6 +165,21 @@ class ServiceAccountCredentialsTests(unittest2.TestCase):
             self.assertEqual(creds._private_key_password, private_key_password)
         self.assertEqual(creds._scopes, ' '.join(scopes))
 
+    def _p12_not_implemented_helper(self):
+        service_account_email = 'name@email.com'
+        filename = data_filename('privatekey.p12')
+        with self.assertRaises(NotImplementedError):
+            ServiceAccountCredentials.from_p12_keyfile(
+                service_account_email, filename)
+
+    @mock.patch('oauth2client.crypt.Signer', new=crypt.PyCryptoSigner)
+    def test_from_p12_keyfile_with_pycrypto(self):
+        self._p12_not_implemented_helper()
+
+    @mock.patch('oauth2client.crypt.Signer', new=crypt.RsaSigner)
+    def test_from_p12_keyfile_with_rsa(self):
+        self._p12_not_implemented_helper()
+
     def test_from_p12_keyfile_defaults(self):
         self._from_p12_keyfile_helper()
 


### PR DESCRIPTION
Fixes #417.

@nathanielmanistaatgoogle I'm not sure why this didn't make it in the re-write. I definitely had tests for this and an `if crypt.Signer` check.

Sorry @ddoskind that I absent-mindedly let it slip in #398 (it was in #392 but I dropped the `_get_signer` helper since only the factories need to make a signer now rather than the constructor back then)
