### PR TITLE
Fix GCE system tests

### DIFF
--- a/scripts/run_gce_system_tests.py
+++ b/scripts/run_gce_system_tests.py
@@ -48,8 +48,6 @@ class TestComputeEngine(unittest.TestCase):
 
         content = content.decode('utf-8')
         payload = json.loads(content)
-        self.assertTrue(payload['email'].endswith(
-            '-compute@developer.gserviceaccount.com'))
         self.assertEqual(payload['access_type'], 'offline')
         self.assertLessEqual(int(payload['expires_in']), 3600)
 


### PR DESCRIPTION
tokeninfo will not tell you the email address for a GCE account. It's sufficient to verify that the token is valid and unexpired.
