### PR TITLE
Allowing default flags in run_flow().

### DIFF
--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -113,7 +113,7 @@ class ClientRedirectHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
 
 @util.positional(3)
-def run_flow(flow, storage, flags, http=None):
+def run_flow(flow, storage, flags=None, http=None):
     """Core code for a command-line application.
 
     The ``run()`` function is called from your application and runs
@@ -154,15 +154,18 @@ def run_flow(flow, storage, flags, http=None):
     Args:
         flow: Flow, an OAuth 2.0 Flow to step through.
         storage: Storage, a ``Storage`` to store the credential in.
-        flags: ``argparse.Namespace``, The command-line flags. This is the
-               object returned from calling ``parse_args()`` on
-               ``argparse.ArgumentParser`` as described above.
+        flags: ``argparse.Namespace``, (Optional) The command-line flags. This
+               is the object returned from calling ``parse_args()`` on
+               ``argparse.ArgumentParser`` as described above. Defaults
+               to ``argparser.parse_args()``.
         http: An instance of ``httplib2.Http.request`` or something that
               acts like it.
 
     Returns:
         Credentials, the obtained credential.
     """
+    if flags is None:
+        flags = argparser.parse_args()
     logging.getLogger().setLevel(getattr(logging, flags.logging_level))
     if not flags.noauth_local_webserver:
         success = False


### PR DESCRIPTION
Resurrects #360. I double checked two different default behaviors to verify this is the "right" way:

``` python
>>> # Method 1
>>> flags = argparser.parse_args()
>>> flags
Namespace(auth_host_name='localhost', auth_host_port=[8080, 8090], logging_level='ERROR', noauth_local_webserver=False)
>>> # Method 2 (same result, but takes more code)
>>> import argparse
>>> parser = argparse.ArgumentParser(parents=[argparser])
>>> flags = parser.parse_args()
>>> flags
Namespace(auth_host_name='localhost', auth_host_port=[8080, 8090], logging_level='ERROR', noauth_local_webserver=False)
```
