### PR TITLE
Moving util.dict_to_tuple_key() into only module that uses it.

### DIFF
--- a/oauth2client/contrib/multistore_file.py
+++ b/oauth2client/contrib/multistore_file.py
@@ -73,6 +73,21 @@ class NewerCredentialStoreError(Error):
     """The credential store is a newer version than supported."""
 
 
+def _dict_to_tuple_key(dictionary):
+    """Converts a dictionary to a tuple that can be used as an immutable key.
+
+    The resulting key is always sorted so that logically equivalent
+    dictionaries always produce an identical tuple for a key.
+
+    Args:
+        dictionary: the dictionary to use as the key.
+
+    Returns:
+        A tuple representing the dictionary in it's naturally sorted ordering.
+    """
+    return tuple(sorted(dictionary.items()))
+
+
 @util.positional(4)
 def get_credential_storage(filename, client_id, user_agent, scope,
                            warn_on_readonly=True):
@@ -139,7 +154,7 @@ def get_credential_storage_custom_key(filename, key_dict,
         credential.
     """
     multistore = _get_multistore(filename, warn_on_readonly=warn_on_readonly)
-    key = util.dict_to_tuple_key(key_dict)
+    key = _dict_to_tuple_key(key_dict)
     return multistore._get_storage(key)
 
 
@@ -404,7 +419,7 @@ class _MultiStore(object):
             OAuth2Credential object.
         """
         raw_key = cred_entry['key']
-        key = util.dict_to_tuple_key(raw_key)
+        key = _dict_to_tuple_key(raw_key)
         credential = None
         credential = Credentials.new_from_json(
             json.dumps(cred_entry['credential']))

--- a/oauth2client/util.py
+++ b/oauth2client/util.py
@@ -183,21 +183,6 @@ def string_to_scopes(scopes):
         return scopes
 
 
-def dict_to_tuple_key(dictionary):
-    """Converts a dictionary to a tuple that can be used as an immutable key.
-
-    The resulting key is always sorted so that logically equivalent
-    dictionaries always produce an identical tuple for a key.
-
-    Args:
-        dictionary: the dictionary to use as the key.
-
-    Returns:
-        A tuple representing the dictionary in it's naturally sorted ordering.
-    """
-    return tuple(sorted(dictionary.items()))
-
-
 def _add_query_parameter(url, name, value):
     """Adds a query parameter to a url.
 

--- a/tests/contrib/test_multistore_file.py
+++ b/tests/contrib/test_multistore_file.py
@@ -48,6 +48,30 @@ class _MockLockedFile(object):
         return self.filename_str
 
 
+class Test__dict_to_tuple_key(unittest2.TestCase):
+
+    def test_key_conversions(self):
+        key1, val1 = 'somekey', 'some value'
+        key2, val2 = 'another', 'something else'
+        key3, val3 = 'onemore', 'foo'
+        test_dict = {
+            key1: val1,
+            key2: val2,
+            key3: val3,
+        }
+        tuple_key = multistore_file._dict_to_tuple_key(test_dict)
+
+        # the resulting key should be naturally sorted
+        expected_output = (
+            (key2, val2),
+            (key3, val3),
+            (key1, val1),
+        )
+        self.assertTupleEqual(expected_output, tuple_key)
+        # check we get the original dictionary back
+        self.assertDictEqual(test_dict, dict(tuple_key))
+
+
 class MultistoreFileTests(unittest2.TestCase):
 
     def tearDown(self):
@@ -257,3 +281,7 @@ class MultistoreFileTests(unittest2.TestCase):
         store2.delete()
         keys = multistore_file.get_all_credential_keys(FILENAME)
         self.assertEquals([], keys)
+
+
+if __name__ == '__main__':  # pragma: NO COVER
+    unittest2.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -42,23 +42,5 @@ class StringToScopeTests(unittest.TestCase):
             self.assertEqual(expected, util.string_to_scopes(case))
 
 
-class KeyConversionTests(unittest.TestCase):
-
-    def test_key_conversions(self):
-        d = {'somekey': 'some value', 'another': 'something else',
-             'onemore': 'foo'}
-        tuple_key = util.dict_to_tuple_key(d)
-
-        # the resulting key should be naturally sorted
-        self.assertEqual(
-            (('another', 'something else'),
-             ('onemore', 'foo'),
-             ('somekey', 'some value')),
-            tuple_key)
-
-        # check we get the original dictionary back
-        self.assertEqual(d, dict(tuple_key))
-
-
 if __name__ == '__main__':  # pragma: NO COVER
     unittest.main()


### PR DESCRIPTION
When I filed #428 I compared the modules to see what was superfluous and noticed that this method only had one user. This change may not be "allowed" since it removes a public interface.
