### PR TITLE
Using mock App Engine module when building docs.

### DIFF
--- a/docs/django_settings.py
+++ b/docs/django_settings.py
@@ -1,1 +1,0 @@
-SECRET_KEY = 'abcdefg'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 django
 flask
 keyring
+mock
 pycrypto>=2.6
 pyopenssl>=0.14
 python-gflags

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -14,14 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Build the oauth2client docs, installing the GAE SDK as needed.
+# Build the oauth2client docs.
 
 set -e
-
-if [[ -z "${SKIP_GAE_SDK}" ]]; then
-  scripts/fetch_gae_sdk.py
-  export PYTHONPATH="${PWD}/google_appengine:${PYTHONPATH}"
-fi
 
 rm -rf docs/_build/* docs/source/*
 sphinx-apidoc --separate --force -o docs/source oauth2client


### PR DESCRIPTION
We have had some partially broken builds in both [`latest`](https://readthedocs.org/projects/oauth2client/builds/3753111/) and [`stable`](https://readthedocs.org/projects/oauth2client/builds/3746690/). See the sixth line in the build for the errors:

```
python /home/docs/checkouts/readthedocs.org/user_builds/oauth2client/envs/stable/bin/sphinx-build -T -b readthedocs -d _build/doctrees-readthedocs -D language=en . _build/html
```

The issue was a flaky snippet that downloaded the GAE SDK and I'm not sure why it worked sometimes and failed sometimes, but there is no reason to require that massive download.
