### PR TITLE
correct p12 example code typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ environment variable.
 For `.p12` keys, construct via
 
 ```py
-credentials = ServiceAccountCredentials.from_p12_keyfil(
+credentials = ServiceAccountCredentials.from_p12_keyfile(
     service_account_email, key_file_name, scopes=[...])
 ```
 


### PR DESCRIPTION
s/ServiceAccountCredentials.from_p12_keyfil/ServiceAccountCredentials.from_p12_keyfile/
