### PR TITLE
compatibility validate_token with python3

### DIFF
--- a/oauth2client/contrib/xsrfutil.py
+++ b/oauth2client/contrib/xsrfutil.py
@@ -101,6 +101,6 @@ def validate_token(key, token, user_id, action_id="", current_time=None):
 
     # Perform constant time comparison to avoid timing attacks
     different = 0
-    for x, y in zip(bytearray(token), bytearray(expected_token)):
+    for x, y in zip(bytearray(token, 'utf-8'), bytearray(expected_token)):
         different |= x ^ y
     return not different


### PR DESCRIPTION
In python3, the encoding is required when create a bytearray from a STRING
