### PR TITLE
Compatibility validate_token with python3

### DIFF
--- a/oauth2client/contrib/xsrfutil.py
+++ b/oauth2client/contrib/xsrfutil.py
@@ -100,7 +100,13 @@ def validate_token(key, token, user_id, action_id="", current_time=None):
         return False
 
     # Perform constant time comparison to avoid timing attacks
+    if isinstance(token, str):
+        zipped_tokens = zip(bytearray(token, 'utf-8'),
+                            bytearray(expected_token))
+    else:
+        zipped_tokens = zip(bytearray(token), bytearray(expected_token))
+
     different = 0
-    for x, y in zip(bytearray(token, 'utf-8'), bytearray(expected_token)):
+    for x, y in zipped_tokens:
         different |= x ^ y
     return not different

--- a/oauth2client/contrib/xsrfutil.py
+++ b/oauth2client/contrib/xsrfutil.py
@@ -101,6 +101,6 @@ def validate_token(key, token, user_id, action_id="", current_time=None):
 
     # Perform constant time comparison to avoid timing attacks
     different = 0
-    for x, y in zip(bytearray(token), bytearray(expected_token)):
+    for x, y in zip(bytearray(token, 'utf-8'), bytearray(expected_token)):
         different |= x ^ y
     return not different

--- a/tests/contrib/test_xsrfutil.py
+++ b/tests/contrib/test_xsrfutil.py
@@ -18,6 +18,7 @@ import base64
 import unittest
 
 import mock
+import six
 
 from oauth2client._helpers import _to_bytes
 from oauth2client.contrib import xsrfutil
@@ -288,6 +289,17 @@ class XsrfUtilTests(unittest.TestCase):
                                                  None,
                                                  TEST_USER_ID_1,
                                                  action_id=TEST_ACTION_ID_1))
+
+        # When the token is a string
+        if six.PY2:
+            str_token = str(token)
+        elif six.PY3:
+            str_token = token.decode('utf-8')
+
+        self.assertTrue(xsrfutil.validate_token(TEST_KEY,
+                                                str_token,
+                                                TEST_USER_ID_1,
+                                                action_id=TEST_ACTION_ID_1))
 
 
 if __name__ == '__main__':  # pragma: NO COVER


### PR DESCRIPTION
In python3, the encoding is required when create a bytearray from a STRING
