### PR TITLE
Update GCE AppAssertionCredentials

### DIFF
--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -183,7 +183,7 @@ class AppAssertionCredentials(AssertionCredentials):
     @property
     def project_id(self):
         if not self._project_id:
-            self._project_id = _get_metadata('project', 'project-id')
+            self._project_id = _get_metadata('project-id')
         return self._project_id
 
     def sign_blob(self, blob):

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -64,6 +64,7 @@ def _get_metadata(http_request=None, path=None, recursive=True):
             with which to make the call to the metadata server
         path: a list of strings denoting the metadata server request
             path.
+
     Returns:
         A deserialized JSON object representing the data returned
         from the metadata server
@@ -102,6 +103,7 @@ def _get_access_token(http_request, email):
         http_request: an httplib2.Http().request object or equivalent
             with which to make the call to the metadata server
         email: The service account email to request an access token with
+
     Returns:
         A tuple (accessToken, token expiry)
     """

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -71,7 +71,7 @@ def _get_metadata(http_request=None, path=None, recursive=True):
     )
     if response.status == http_client.OK:
         decoded = _from_bytes(content)
-        if recursive:
+        if response['content-type'] == 'application/json':
             return json.loads(decoded)
         else:
             return decoded
@@ -99,7 +99,8 @@ def _get_access_token(http_request, email):
             'service-accounts',
             email,
             'token'
-        ]
+        ],
+        recursive=False
     )
     token_expiry = datetime.datetime.now() + datetime.timedelta(
         seconds=token_json.get('expires_in')

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -16,19 +16,18 @@
 
 Utilities for making it easier to use OAuth 2.0 on Google Compute Engine.
 """
-
+import datetime
 import json
 import logging
 import warnings
-import datetime
 
 import httplib2
 from six.moves import http_client
 
-from oauth2client._helpers import _from_bytes
 from oauth2client.client import HttpAccessTokenRefreshError
 from oauth2client.client import AssertionCredentials
-
+from oauth2client._helpers import _from_bytes
+from oauth2client.contrib.iam_signer import IAMSigner
 
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -163,9 +163,10 @@ class AppAssertionCredentials(AssertionCredentials):
         super(AppAssertionCredentials, self).__init__(
             None, scopes=scope, **kwargs)
 
-        self._service_account_info = {}
-        if service_account_email:
-            self._service_account_info['email'] = service_account_email
+        if service_account_email is None:
+            self._service_account_info = {}
+        else:
+            self._service_account_info = {'email': service_account_email}
 
         self._project_id = None
         self._partial = True

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -36,7 +36,7 @@ __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 logger = logging.getLogger(__name__)
 
 # URI Template for the endpoint that returns access_tokens.
-_METADATA_ROOT = 'http://metadata.google.internal/v1/computeMetadata/'
+_METADATA_ROOT = 'http://metadata.google.internal/computeMetadata/v1/'
 _SCOPES_WARNING = """\
 You have requested explicit scopes to be used with a GCE service account.
 Using this argument will have no effect on the actual scopes for tokens

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -20,9 +20,9 @@ Utilities for making it easier to use OAuth 2.0 on Google Compute Engine.
 import json
 import logging
 import warnings
+import datetime
 
 import httplib2
-import datetime
 from six.moves import http_client
 
 from oauth2client._helpers import _from_bytes

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -74,7 +74,7 @@ def _get_metadata(http_request=None,
     )
     if response.status == http_client.OK:
         decoded = _from_bytes(content)
-        if recursive:
+        if returns_json:
             return json.loads(decoded)
         else:
             return decoded
@@ -102,7 +102,8 @@ def _get_access_token(http_request, email):
             'service-accounts',
             email,
             'token'
-        ]
+        ],
+        recursive=False
     )
     token_expiry = datetime.datetime.now() + datetime.timedelta(
         seconds=token_json.get('expires_in')

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # URI Template for the endpoint that returns access_tokens.
 _METADATA_ROOT = 'http://metadata.google.internal/computeMetadata/v1/'
 # Backwards Compat
-META = _METADATA_ROOT + '/instance/service-accounts/default/token'
+META = _METADATA_ROOT + 'instance/service-accounts/default/token'
 _SCOPES_WARNING = """\
 You have specified explicit scopes to be used with a GCE service account
 credentials, and these scopes *are* present on the credentials.

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -45,7 +45,10 @@ can't be overridden in the request.
 """
 
 
-def _get_metadata(http_request=None, path=None, recursive=True):
+def _get_metadata(http_request=None,
+                  path=None,
+                  recursive=True,
+                  returns_json=True):
     """Gets a JSON object from the specified path on the Metadata Server
     Args:
         http_request: an httplib2.Http().request object or equivalent
@@ -187,7 +190,8 @@ class AppAssertionCredentials(AssertionCredentials):
         if not self._project_id:
             self._project_id = _get_metadata(
                 path=['project', 'project-id'],
-                recursive=False
+                recursive=False,
+                returns_json=False
             )
         return self._project_id
 

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -36,7 +36,7 @@ __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 logger = logging.getLogger(__name__)
 
 # URI Template for the endpoint that returns access_tokens.
-_METADATA_ROOT = 'http://metadata.google.internal/v1/computeMetadata'
+_METADATA_ROOT = 'http://metadata.google.internal/v1/computeMetadata/'
 _SCOPES_WARNING = """\
 You have requested explicit scopes to be used with a GCE service account.
 Using this argument will have no effect on the actual scopes for tokens

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -72,9 +72,9 @@ def _get_metadata(http_request=None, path=None):
         return json.loads(_from_bytes(content))
     else:
         msg = (
-            'Failed to retrieve {} from the Google Compute Engine'
-            'metadata service. Response:\n{}'
-        ).format(full_path, response)
+            'Failed to retrieve {path} from the Google Compute Engine'
+            'metadata service. Response:\n{error}'
+        ).format(path=full_path, error=response)
         raise AttributeError(msg)
 
 

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -74,7 +74,7 @@ def _get_metadata(http_request=None,
     )
     if response.status == http_client.OK:
         decoded = _from_bytes(content)
-        if returns_json:
+        if recursive:
             return json.loads(decoded)
         else:
             return decoded
@@ -102,8 +102,7 @@ def _get_access_token(http_request, email):
             'service-accounts',
             email,
             'token'
-        ],
-        recursive=False
+        ]
     )
     token_expiry = datetime.datetime.now() + datetime.timedelta(
         seconds=token_json.get('expires_in')

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -35,8 +35,10 @@ logger = logging.getLogger(__name__)
 
 # URI Template for the endpoint that returns access_tokens.
 _METADATA_ROOT = 'http://metadata.google.internal/computeMetadata/v1/'
+# Backwards Compat
+META = _METADATA_ROOT + '/instance/service-accounts/default/token'
 _SCOPES_WARNING = """\
-You have requested explicit scopes to be used with a GCE service account
+You have specified explicit scopes to be used with a GCE service account
 credentials, and these scopes *are* present on the credentials.
 However, setting scopes on the GCE service account credentials has no effect
 on the actual scopes for tokens requested. The credentials scopes
@@ -44,7 +46,7 @@ are set at VM instance creation time and can't be overridden in the request.
 To learn more go to https://cloud.google.com/compute/docs/authentication .
 """
 _SCOPES_ERROR = """\
-You have requested explicit scopes to be used with a GCE service account
+You have specified explicit scopes to be used with a GCE service account
 which are not available on the credentials. The scopes are set at VM instance
 creation time and can't be overridden in the request.
 To learn more go to https://cloud.google.com/compute/docs/authentication .
@@ -175,6 +177,7 @@ class AppAssertionCredentials(AssertionCredentials):
 
         # This function call must be made because AssertionCredentials
         # will not pass the scopes kwarg to parent class
+        # In a breaking version change, remove the scope kwarg
         self._check_scopes_and_notify(scope)
 
     @property
@@ -263,8 +266,7 @@ class AppAssertionCredentials(AssertionCredentials):
             self._service_account_info.get('email', 'default'))
 
     def create_scoped(self, scopes):
-        # Trigger warning or error based on scopes
-        self.scopes = scopes
+        self._check_scopes_and_notify(scopes)
         # No need for new object creation
         return self
 

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -46,7 +46,7 @@ can't be overridden in the request.
 
 
 def _get_metadata(http_request=None, path=None):
-    """
+    """Gets a JSON object from the specified path on the Metadata Server
     Args:
         http_request: an httplib2.Http().request object or equivalent
             with which to make the call to the metadata server
@@ -79,7 +79,7 @@ def _get_metadata(http_request=None, path=None):
 
 
 def _get_access_token(http_request, email):
-    """
+    """Get an access token for the specified email from the Metadata Server.
     Args:
         http_request: an httplib2.Http().request object or equivalent
             with which to make the call to the metadata server
@@ -158,6 +158,12 @@ class AppAssertionCredentials(AssertionCredentials):
 
     @property
     def service_account_info(self):
+        """Info about this service account
+        By using _get_service_account_info this property is
+        always guaranteed to have the following members:
+            'email', 'scopes'
+        It may also have the member: 'aliases'
+        """
         return self._get_service_account_info()
 
     @property
@@ -183,7 +189,7 @@ class AppAssertionCredentials(AssertionCredentials):
         return {'service_account_info': self.service_account_info}
 
     def _get_service_account_info(self, http_request=None):
-        """
+        """Retrieves the full info for a service account and caches it.
         Args:
             http_request: an httplib2.Http().request object or equivalent
                 with which to make the call to the metadata server
@@ -208,7 +214,9 @@ class AppAssertionCredentials(AssertionCredentials):
         return self._service_account_info
 
     def _retrieve_scopes(self, http_request):
-        return self._get_service_account_info(http_request=http_request)
+        return self._get_service_account_info(
+            http_request=http_request
+        )['scopes']
 
     def _refresh(self, http_request):
         """Refreshes the access_token.
@@ -251,11 +259,9 @@ class AppAssertionCredentials(AssertionCredentials):
             NotImplementedError, always.
         """
         raise NotImplementedError(
-            'Compute Engine service accounts cannot sign blobs'
-        )
+            'Compute Engine service accounts cannot sign blobs')
 
     def to_json(self):
-        # Why is this not default -_-
         return self._to_json(
             self.NON_SERIALIZED_MEMBERS,
             to_serialize=self.serialization_data

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -16,6 +16,7 @@
 
 Utilities for making it easier to use OAuth 2.0 on Google Compute Engine.
 """
+
 import datetime
 import json
 import logging
@@ -35,9 +36,10 @@ logger = logging.getLogger(__name__)
 # URI Template for the endpoint that returns access_tokens.
 _METADATA_ROOT = 'http://metadata.google.internal/computeMetadata/v1/'
 _SCOPES_WARNING = """\
-You have requested explicit scopes to be used with a GCE service account, and
-these scopes *are* present on the credentials. However, this request will have
-no effect on the actual scopes for tokens requested. The credentials scopes
+You have requested explicit scopes to be used with a GCE service account
+credentials, and these scopes *are* present on the credentials.
+However, setting scopes on the GCE service account credentials has no effect
+on the actual scopes for tokens requested. The credentials scopes
 are set at VM instance creation time and can't be overridden in the request.
 To learn more go to https://cloud.google.com/compute/docs/authentication .
 """

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -239,6 +239,7 @@ class AppAssertionCredentials(AssertionCredentials):
         Args:
             http_request: an httplib2.Http().request object or equivalent
                 with which to make the call to the metadata server
+
         Returns:
             A deserialized JSON service account object of the form:
                 {

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -208,7 +208,7 @@ class AppAssertionCredentials(AssertionCredentials):
                 http_request,
                 email=self.service_account_email
             )
-        except Exception as e:
+        except (AttributeError, ValueError) as e:
             raise HttpAccessTokenRefreshError(str(e))
 
     def create_scoped_required(self):

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -129,6 +129,11 @@ def _get_access_token(http_request, email):
     return token_json['access_token'], token_expiry
 
 
+def get_project_id():
+    return _get_metadata(
+        path=['project', 'project-id'], recursive=False)
+
+
 class AppAssertionCredentials(AssertionCredentials):
     """Credentials object for Compute Engine Assertion Grants
 
@@ -201,13 +206,6 @@ class AppAssertionCredentials(AssertionCredentials):
     @property
     def service_account_email(self):
         return self.service_account_info['email']
-
-    @property
-    def project_id(self):
-        if not self._project_id:
-            self._project_id = _get_metadata(
-                path=['project', 'project-id'], recursive=False)
-        return self._project_id
 
     @property
     def serialization_data(self):

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -75,7 +75,7 @@ def _get_metadata(http_request=None, path=None):
             'Failed to retrieve {path} from the Google Compute Engine'
             'metadata service. Response:\n{error}'
         ).format(path=full_path, error=response)
-        raise AttributeError(msg)
+        raise ValueError(msg)
 
 
 def _get_access_token(http_request, email):
@@ -236,7 +236,7 @@ class AppAssertionCredentials(AssertionCredentials):
                 http_request,
                 self._service_account_info['email']
             )
-        except (AttributeError, ValueError) as e:
+        except ValueError as e:
             raise HttpAccessTokenRefreshError(str(e))
 
     def create_scoped(self, scopes):

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -48,7 +48,7 @@ def _get_metadata(http_request=None, *path):
     if not http_request:
         http_request = httplib2.Http().request
     full_path = "/".join(path.insert(0, _METADATA_ROOT))
-    response, content = http_client.request(
+    response, content = http_request(
         full_path,
         headers={'Metadata-Flavor': 'Google'}
     )

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -27,7 +27,6 @@ from six.moves import http_client
 from oauth2client.client import HttpAccessTokenRefreshError
 from oauth2client.client import AssertionCredentials
 from oauth2client._helpers import _from_bytes
-from oauth2client.contrib.iam_signer import IAMSigner
 
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -160,8 +160,7 @@ class AppAssertionCredentials(AssertionCredentials):
     def service_account_info(self):
         """Info about this service account
         By using _get_service_account_info this property is
-        always guaranteed to have the following members:
-            'email', 'scopes'
+        always guaranteed to have the members ['email', 'scopes'].
         It may also have the member: 'aliases'
         """
         return self._get_service_account_info()

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -132,7 +132,11 @@ class AppAssertionCredentials(AssertionCredentials):
     """
 
     @util.positional(2)
-    def __init__(self, scope='', service_account_email='default', **kwargs):
+    def __init__(self,
+                 scope='',
+                 service_account_email='default',
+                 service_account_info=None,
+                 **kwargs):
         """Constructor for AppAssertionCredentials
 
         Args:
@@ -146,11 +150,15 @@ class AppAssertionCredentials(AssertionCredentials):
                 service accounts, or left blank to use the default service
                 account for the instance. Usually the compute engine service
                 account.
+            service_account_info:
+                Deserialized JSON object, returned by self.service_account_info
         """
         if scope:
             warnings.warn(_SCOPES_WARNING)
 
-        self._service_account_info = {'email': service_account_email}
+        self._service_account_info = service_account_info or {
+            'email': service_account_email
+        }
         self._project_id = None
 
         self.kwargs = kwargs
@@ -169,7 +177,7 @@ class AppAssertionCredentials(AssertionCredentials):
 
     @property
     def scopes(self):
-        return self._retrieve_scopes(httplib2.Http().request)
+        return self._retrieve_scopes()
 
     @property
     def service_account_email(self):
@@ -183,9 +191,7 @@ class AppAssertionCredentials(AssertionCredentials):
 
     @property
     def serialization_data(self):
-        return {
-            'email': self.service_account_email
-        }
+        return self.service_account_info
 
     def _retrieve_scopes(self, http_request):
         return self.service_account_info['scopes']
@@ -237,5 +243,5 @@ class AppAssertionCredentials(AssertionCredentials):
     @classmethod
     def from_json(cls, json_data):
         return AppAssertionCredentials(
-            service_account_email=json_data['email']
+            service_account_info=json_data
         )

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -45,10 +45,7 @@ can't be overridden in the request.
 """
 
 
-def _get_metadata(http_request=None,
-                  path=None,
-                  recursive=True,
-                  returns_json=True):
+def _get_metadata(http_request=None, path=None, recursive=True):
     """Gets a JSON object from the specified path on the Metadata Server
     Args:
         http_request: an httplib2.Http().request object or equivalent
@@ -190,8 +187,7 @@ class AppAssertionCredentials(AssertionCredentials):
         if not self._project_id:
             self._project_id = _get_metadata(
                 path=['project', 'project-id'],
-                recursive=False,
-                returns_json=False
+                recursive=False
             )
         return self._project_id
 

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -193,13 +193,9 @@ class AppAssertionCredentials(AssertionCredentials):
     def service_account_info(self):
         """Info about this service account.
 
-        this property is a deserialized JSON service account object of the form
-        {
-            'aliases': [...],
-            'scopes': [...],
-            'email': 'a@example.com'
-        }
-        Where 'scopes' and 'email' will always be present
+        This property is a deserialized JSON service account object of the form
+        {'aliases': [...], 'scopes': [...], 'email': 'a@example.com'}
+        where 'scopes' and 'email' will always be present.
         """
         return self._get_service_account_info()
 

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -14,32 +14,45 @@
 
 """Unit tests for oauth2client.contrib.gce."""
 
-import json
 from six.moves import http_client
-from six.moves import urllib
 import unittest2
-
+import time
 import mock
+import json
 
 import httplib2
-from oauth2client._helpers import _to_bytes
-from oauth2client.client import AccessTokenRefreshError
-from oauth2client.client import Credentials
-from oauth2client.client import save_to_well_known_file
-from oauth2client.contrib.gce import _DEFAULT_EMAIL_METADATA
-from oauth2client.contrib.gce import _get_service_account_email
-from oauth2client.contrib.gce import _SCOPES_WARNING
-from oauth2client.contrib.gce import AppAssertionCredentials
-
+from oauth2client.client import HttpAccessTokenRefreshError,\
+    Credentials,\
+    save_to_well_known_file
+from oauth2client.contrib.gce import _SCOPES_WARNING,\
+    _METADATA_ROOT,\
+    _get_metadata,\
+    AppAssertionCredentials
+import tempfile
 
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
+
+METADATA_SERVER = 'oauth2client.contrib.gce._get_metadata'
+DEFAULT_SERVICE_ACCOUNT = {'email': 'default'}
+A_SERVICE_ACCOUNT = {
+    'scopes': [
+        'https://www.googleapis.com/auth/cloud-platform',
+        'https://www.googleapis.com/auth/iam'
+    ],
+    'email': '12345678-compute@developer.gserviceaccount.com'
+}
+
+GET_ACCESS_TOKEN = 'oauth2client.contrib.gce._get_access_token'
+ONE_SECOND_TOKEN = {'access_token': '12345abcde', 'expires_in': 1}
+FOREVER_TOKEN = {'access_token': '12345abcde', 'expires_in': 999999999}
 
 
 class AppAssertionCredentialsTests(unittest2.TestCase):
 
+    # BASIC TESTS
+
     def test_constructor(self):
         credentials = AppAssertionCredentials(foo='bar')
-        self.assertEqual(credentials.scope, '')
         self.assertEqual(credentials.kwargs, {'foo': 'bar'})
         self.assertEqual(credentials.assertion_type, None)
 
@@ -47,44 +60,98 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
     def test_constructor_with_scopes(self, warn_mock):
         scope = 'http://example.com/a http://example.com/b'
         scopes = scope.split()
-        credentials = AppAssertionCredentials(scope=scopes, foo='bar')
-        self.assertEqual(credentials.scope, scope)
-        self.assertEqual(credentials.kwargs, {'foo': 'bar'})
-        self.assertEqual(credentials.assertion_type, None)
+        AppAssertionCredentials(scope=scopes)
         warn_mock.assert_called_once_with(_SCOPES_WARNING)
 
-    def test_to_json_and_from_json(self):
+    @mock.patch(METADATA_SERVER, return_value=A_SERVICE_ACCOUNT)
+    def test_default_service_account_info(self, get_metadata):
         credentials = AppAssertionCredentials()
-        json = credentials.to_json()
-        credentials_from_json = Credentials.new_from_json(json)
-        self.assertEqual(credentials.access_token,
-                         credentials_from_json.access_token)
+        self.assertEquals(
+            credentials._service_account_info,
+            DEFAULT_SERVICE_ACCOUNT
+        )
+        self.assertEquals(credentials.scopes, A_SERVICE_ACCOUNT['scopes'])
+        self.assertEquals(
+            credentials.service_account_email,
+            A_SERVICE_ACCOUNT['email']
+        )
+        self.assertEquals(credentials.service_account_info, A_SERVICE_ACCOUNT)
+        get_metadata.assert_called_once_with(
+            path=[
+                'instance',
+                'service-accounts',
+                'default'
+            ],
+            http_request=None
+        )
 
-    def _refresh_success_helper(self, bytes_response=False):
-        access_token = u'this-is-a-token'
-        return_val = json.dumps({u'access_token': access_token})
-        if bytes_response:
-            return_val = _to_bytes(return_val)
-        http = mock.MagicMock()
-        http.request = mock.MagicMock(
-            return_value=(mock.Mock(status=http_client.OK), return_val))
+    @mock.patch(METADATA_SERVER, return_value=A_SERVICE_ACCOUNT)
+    def test_custom_service_account_info(self, get_metadata):
+        credentials = AppAssertionCredentials(
+            service_account_email=A_SERVICE_ACCOUNT['email']
+        )
+        self.assertEquals(
+            credentials._service_account_info,
+            {'email': A_SERVICE_ACCOUNT['email']}
+        )
+        self.assertEquals(credentials.scopes, A_SERVICE_ACCOUNT['scopes'])
+        self.assertEquals(
+            credentials.service_account_email,
+            A_SERVICE_ACCOUNT['email']
+        )
+        self.assertEquals(credentials.service_account_info, A_SERVICE_ACCOUNT)
+        get_metadata.assert_called_once_with(
+            path=[
+                'instance',
+                'service-accounts',
+                A_SERVICE_ACCOUNT['email']
+            ],
+            http_request=None
+        )
 
+    @mock.patch(METADATA_SERVER, return_value='a-project-id')
+    def test_project_id(self, get_metadata):
+        credentials = AppAssertionCredentials()
+        self.assertIsNone(credentials._project_id)
+        self.assertEquals(credentials.project_id, 'a-project-id')
+        self.assertEquals(credentials.project_id, 'a-project-id')
+        get_metadata.assert_called_once_with(
+            path=[
+                'project',
+                'project-id'
+            ],
+        )
+
+    def test_refresh_token(self):
         credentials = AppAssertionCredentials()
         self.assertEquals(None, credentials.access_token)
-        credentials.refresh(http)
-        self.assertEquals(access_token, credentials.access_token)
 
-        base_metadata_uri = (
-            'http://metadata.google.internal/computeMetadata/v1/instance/'
-            'service-accounts/default/token')
-        http.request.assert_called_once_with(
-            base_metadata_uri, headers={'Metadata-Flavor': 'Google'})
+        with mock.patch(METADATA_SERVER, return_value=ONE_SECOND_TOKEN):
+            credentials.get_access_token()
+            time.sleep(2)
+            self.assertTrue(credentials.access_token_expired)
 
-    def test_refresh_success(self):
-        self._refresh_success_helper(bytes_response=False)
+        with mock.patch(METADATA_SERVER, return_value=FOREVER_TOKEN):
+            credentials.get_access_token()
+            self.assertFalse(credentials.access_token_expired)
 
-    def test_refresh_success_bytes(self):
-        self._refresh_success_helper(bytes_response=True)
+    @mock.patch(METADATA_SERVER, return_value=A_SERVICE_ACCOUNT)
+    def test_serialize_deserialize(self, get_metadata):
+        credentials = AppAssertionCredentials()
+        credentials_from_json = Credentials.new_from_json(
+            credentials.to_json()
+        )
+        self.assertTrue(
+            credentials.service_account_info,
+            credentials_from_json.service_account_info
+        )
+
+    # ERROR TESTS
+
+    def test_sign_blob_not_implemented(self):
+        credentials = AppAssertionCredentials([])
+        with self.assertRaises(NotImplementedError):
+            credentials.sign_blob(b'blob')
 
     def test_refresh_failure_bad_json(self):
         http = mock.MagicMock()
@@ -93,23 +160,27 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
             return_value=(mock.Mock(status=http_client.OK), content))
 
         credentials = AppAssertionCredentials()
-        self.assertRaises(AccessTokenRefreshError, credentials.refresh, http)
+        self.assertRaises(
+            HttpAccessTokenRefreshError,
+            credentials.refresh,
+            http
+        )
 
     def test_refresh_failure_400(self):
         http = mock.MagicMock()
         content = '{}'
         http.request = mock.MagicMock(
-            return_value=(mock.Mock(status=http_client.BAD_REQUEST), content))
+            return_value=(mock.Mock(status=http_client.BAD_REQUEST), content)
+        )
 
         credentials = AppAssertionCredentials()
         exception_caught = None
         try:
             credentials.refresh(http)
-        except AccessTokenRefreshError as exc:
+        except HttpAccessTokenRefreshError as exc:
             exception_caught = exc
 
         self.assertNotEqual(exception_caught, None)
-        self.assertEqual(str(exception_caught), content)
 
     def test_refresh_failure_404(self):
         http = mock.MagicMock()
@@ -121,132 +192,54 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
         exception_caught = None
         try:
             credentials.refresh(http)
-        except AccessTokenRefreshError as exc:
+        except HttpAccessTokenRefreshError as exc:
             exception_caught = exc
 
         self.assertNotEqual(exception_caught, None)
-        expanded_content = content + (' This can occur if a VM was created'
-                                      ' with no service account or scopes.')
-        self.assertEqual(str(exception_caught), expanded_content)
 
-    def test_serialization_data(self):
-        credentials = AppAssertionCredentials()
-        self.assertRaises(NotImplementedError, getattr,
-                          credentials, 'serialization_data')
-
-    def test_create_scoped_required_without_scopes(self):
-        credentials = AppAssertionCredentials()
-        self.assertFalse(credentials.create_scoped_required())
-
-    @mock.patch('warnings.warn')
-    def test_create_scoped_required_with_scopes(self, warn_mock):
-        credentials = AppAssertionCredentials(['dummy_scope'])
-        self.assertFalse(credentials.create_scoped_required())
-        warn_mock.assert_called_once_with(_SCOPES_WARNING)
-
-    @mock.patch('warnings.warn')
-    def test_create_scoped(self, warn_mock):
-        credentials = AppAssertionCredentials()
-        new_credentials = credentials.create_scoped(['dummy_scope'])
-        self.assertNotEqual(credentials, new_credentials)
-        self.assertTrue(isinstance(new_credentials, AppAssertionCredentials))
-        self.assertEqual('dummy_scope', new_credentials.scope)
-        warn_mock.assert_called_once_with(_SCOPES_WARNING)
-
-    def test_sign_blob_not_implemented(self):
-        credentials = AppAssertionCredentials([])
-        with self.assertRaises(NotImplementedError):
-            credentials.sign_blob(b'blob')
-
-    @mock.patch('oauth2client.contrib.gce._get_service_account_email',
-                return_value=(None, 'retrieved@email.com'))
-    def test_service_account_email(self, get_email):
-        credentials = AppAssertionCredentials([])
-        self.assertIsNone(credentials._service_account_email)
-        self.assertEqual(credentials.service_account_email,
-                         get_email.return_value[1])
-        self.assertIsNotNone(credentials._service_account_email)
-        get_email.assert_called_once_with()
-
-    @mock.patch('oauth2client.contrib.gce._get_service_account_email')
-    def test_service_account_email_already_set(self, get_email):
-        credentials = AppAssertionCredentials([])
-        acct_name = 'existing@email.com'
-        credentials._service_account_email = acct_name
-        self.assertEqual(credentials.service_account_email, acct_name)
-        get_email.assert_not_called()
-
-    @mock.patch('oauth2client.contrib.gce._get_service_account_email')
-    def test_service_account_email_failure(self, get_email):
+    def test_scopes_failure(self):
         # Set-up the mock.
-        bad_response = httplib2.Response({'status': http_client.NOT_FOUND})
-        content = b'bad-bytes-nothing-here'
-        get_email.return_value = (bad_response, content)
-        # Test the failure.
-        credentials = AppAssertionCredentials([])
-        self.assertIsNone(credentials._service_account_email)
-        with self.assertRaises(AttributeError) as exc_manager:
-            getattr(credentials, 'service_account_email')
-
-        error_msg = ('Failed to retrieve the email from the '
-                     'Google Compute Engine metadata service')
-        self.assertEqual(
-            exc_manager.exception.args,
-            (error_msg, bad_response, content))
-        self.assertIsNone(credentials._service_account_email)
-        get_email.assert_called_once_with()
-
-    def test_get_access_token(self):
         http = mock.MagicMock()
+        content = '{}'
         http.request = mock.MagicMock(
-            return_value=(mock.Mock(status=http_client.OK),
-                          '{"access_token": "this-is-a-token"}'))
-
+            return_value=(mock.Mock(status=http_client.NOT_FOUND), content))
+        # Test the failure.
         credentials = AppAssertionCredentials()
-        token = credentials.get_access_token(http=http)
-        self.assertEqual('this-is-a-token', token.access_token)
-        self.assertEqual(None, token.expires_in)
 
-        http.request.assert_called_once_with(
-            'http://metadata.google.internal/computeMetadata/v1/instance/'
-            'service-accounts/default/token',
-            headers={'Metadata-Flavor': 'Google'})
-
-    def test_save_to_well_known_file(self):
-        import os
-        ORIGINAL_ISDIR = os.path.isdir
+        error = None
         try:
-            os.path.isdir = lambda path: True
+            credentials._retrieve_scopes(http.request)
+        except AttributeError as e:
+            error = e
+
+        self.assertIsNotNone(error)
+
+        self.assertEquals(
+            credentials._service_account_info['email'],
+            'default'
+        )
+        self.assertFalse(
+            'scopes' in credentials._service_account_info
+        )
+
+    @mock.patch(METADATA_SERVER, return_value=A_SERVICE_ACCOUNT)
+    def test_save_to_well_known_file(self, get_metadata):
+        with tempfile.NamedTemporaryFile() as f:
             credentials = AppAssertionCredentials()
-            self.assertRaises(NotImplementedError, save_to_well_known_file,
-                              credentials)
-        finally:
-            os.path.isdir = ORIGINAL_ISDIR
+            save_to_well_known_file(credentials, well_known_file=f.name)
 
 
-class Test__get_service_account_email(unittest2.TestCase):
+class Test__get_metadata(unittest2.TestCase):
 
     def test_success(self):
         http_request = mock.MagicMock()
-        acct_name = b'1234567890@developer.gserviceaccount.com'
+        data = json.dumps(A_SERVICE_ACCOUNT).encode('utf-8')
         http_request.return_value = (
-            httplib2.Response({'status': http_client.OK}), acct_name)
-        result = _get_service_account_email(http_request)
-        self.assertEqual(result, (None, acct_name.decode('utf-8')))
+            httplib2.Response({'status': http_client.OK}), data)
+        result = _get_metadata(http_request)
+        self.assertEqual(result, json.loads(data.decode('utf-8')))
         http_request.assert_called_once_with(
-            _DEFAULT_EMAIL_METADATA,
-            headers={'Metadata-Flavor': 'Google'})
-
-    @mock.patch.object(httplib2.Http, 'request')
-    def test_success_default_http(self, http_request):
-        # Don't make _from_bytes() work too hard.
-        acct_name = u'1234567890@developer.gserviceaccount.com'
-        http_request.return_value = (
-            httplib2.Response({'status': http_client.OK}), acct_name)
-        result = _get_service_account_email()
-        self.assertEqual(result, (None, acct_name))
-        http_request.assert_called_once_with(
-            _DEFAULT_EMAIL_METADATA,
+            _METADATA_ROOT + '/?recursive=true',
             headers={'Metadata-Flavor': 'Google'})
 
     def test_failure(self):
@@ -254,11 +247,15 @@ class Test__get_service_account_email(unittest2.TestCase):
         response = httplib2.Response({'status': http_client.NOT_FOUND})
         content = b'Not found'
         http_request.return_value = (response, content)
-        result = _get_service_account_email(http_request)
+        error = None
+        try:
+            _get_metadata(http_request)
+        except AttributeError as e:
+            error = e
 
-        self.assertEqual(result, (response, content))
+        self.assertIsNotNone(error)
         http_request.assert_called_once_with(
-            _DEFAULT_EMAIL_METADATA,
+            _METADATA_ROOT + '/?recursive=true',
             headers={'Metadata-Flavor': 'Google'})
 
 

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -29,6 +29,7 @@ from oauth2client.contrib.gce import _METADATA_ROOT
 from oauth2client.contrib.gce import _get_metadata
 from oauth2client.contrib.gce import AppAssertionCredentials
 from oauth2client.contrib.gce import MetadataServerHttpError
+from oauth2client.contrib.gce import get_project_id
 from six.moves import http_client
 
 
@@ -104,15 +105,6 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
                   'service-accounts',
                   get_metadata.return_value['email']],
             http_request=None)
-
-    @mock.patch(METADATA_SERVER, return_value='a-project-id')
-    def test_project_id(self, get_metadata):
-        credentials = AppAssertionCredentials()
-        self.assertIsNone(credentials._project_id)
-        self.assertEqual(credentials.project_id, 'a-project-id')
-        self.assertEqual(credentials.project_id, 'a-project-id')
-        get_metadata.assert_called_once_with(
-            path=['project', 'project-id'], recursive=False)
 
     @mock.patch(METADATA_SERVER, return_value=FOREVER_TOKEN)
     def test_refresh_token(self, get_metadata):
@@ -232,6 +224,13 @@ class Test__get_metadata(unittest2.TestCase):
         http_request.assert_called_once_with(
             _METADATA_ROOT + '/?recursive=true',
             headers={'Metadata-Flavor': 'Google'})
+
+    @mock.patch(METADATA_SERVER, return_value='a-project-id')
+    def test_project_id(self, get_metadata):
+        project_id = get_project_id()
+        self.assertEqual(project_id, 'a-project-id')
+        get_metadata.assert_called_once_with(
+            path=['project', 'project-id'], recursive=False)
 
     def test_success_not_json(self):
         http_request = mock.MagicMock()

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -227,7 +227,7 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
         error = None
         try:
             credentials._retrieve_scopes(http.request)
-        except AttributeError as e:
+        except ValueError as e:
             error = e
 
         self.assertIsNotNone(error)
@@ -268,7 +268,7 @@ class Test__get_metadata(unittest2.TestCase):
         error = None
         try:
             _get_metadata(http_request)
-        except AttributeError as e:
+        except ValueError as e:
             error = e
 
         self.assertIsNotNone(error)

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -130,6 +130,7 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
                 'project',
                 'project-id'
             ],
+            recursive=False
         )
 
     def test_refresh_token(self):

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -14,14 +14,14 @@
 
 """Unit tests for oauth2client.contrib.gce."""
 import json
+import tempfile
+import unittest2
+import mock
 from datetime import datetime
 from datetime import timedelta
 
-from six.moves import http_client
-import unittest2
-import mock
-
 import httplib2
+from six.moves import http_client
 from oauth2client.client import HttpAccessTokenRefreshError
 from oauth2client.client import Credentials
 from oauth2client.client import save_to_well_known_file
@@ -30,7 +30,6 @@ from oauth2client.contrib.gce import _METADATA_ROOT
 from oauth2client.contrib.gce import _get_metadata
 from oauth2client.contrib.gce import AppAssertionCredentials
 from oauth2client.contrib.gce import MetadataServerHttpError
-import tempfile
 
 
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """Unit tests for oauth2client.contrib.gce."""
-from datetime import datetime
-from datetime import timedelta
+
+import datetime
 import json
 import mock
 import tempfile
@@ -145,19 +145,19 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
 
         with mock.patch('oauth2client.contrib.gce._NOW',
                         side_effect=[
-                            datetime.min,
-                            datetime.max
+                            datetime.datetime.min,
+                            datetime.datetime.max
                         ]):
             credentials.get_access_token()
             self.assertTrue(credentials.access_token_expired)
 
         with mock.patch('oauth2client.contrib.gce._NOW',
                         side_effect=[
-                            datetime.max - timedelta(
+                            datetime.datetime.max - datetime.timedelta(
                                 seconds=get_metadata.return_value['expires_in']
                             ),  # Force refresh
-                            datetime.min,
-                            datetime.min
+                            datetime.datetime.min,
+                            datetime.datetime.min
                         ]):
             credentials.get_access_token()
             self.assertFalse(credentials.access_token_expired)

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -281,6 +281,18 @@ class Test__get_metadata(unittest2.TestCase):
             _METADATA_ROOT + '/?recursive=true',
             headers={'Metadata-Flavor': 'Google'})
 
+    def test_success_not_json(self):
+        http_request = mock.MagicMock()
+        data = '12345'.encode('utf-8')
+        http_request.return_value = (
+            httplib2.Response({'status': http_client.OK,
+                               'content-type': 'text/plain'}), data)
+        result = _get_metadata(http_request, recursive=False)
+        self.assertEqual(result, data.decode('utf-8'))
+        http_request.assert_called_once_with(
+            _METADATA_ROOT,
+            headers={'Metadata-Flavor': 'Google'})
+
 
 if __name__ == '__main__':  # pragma: NO COVER
     unittest2.main()

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -130,7 +130,8 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
                 'project',
                 'project-id'
             ],
-            recursive=False
+            recursive=False,
+            returns_json=False
         )
 
     def test_refresh_token(self):

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -176,7 +176,10 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
         http = mock.MagicMock()
         content = '{BADJSON'
         http.request = mock.MagicMock(
-            return_value=(mock.Mock(status=http_client.OK), content))
+            return_value=(httplib2.Response({
+                'status': http_client.OK,
+                'content-type': 'application/json'
+            }), content))
 
         credentials = AppAssertionCredentials()
         self.assertRaises(
@@ -254,7 +257,8 @@ class Test__get_metadata(unittest2.TestCase):
         http_request = mock.MagicMock()
         data = json.dumps(A_SERVICE_ACCOUNT).encode('utf-8')
         http_request.return_value = (
-            httplib2.Response({'status': http_client.OK}), data)
+            httplib2.Response({'status': http_client.OK,
+                               'content-type': 'application/json'}), data)
         result = _get_metadata(http_request)
         self.assertEqual(result, json.loads(data.decode('utf-8')))
         http_request.assert_called_once_with(

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -130,8 +130,7 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
                 'project',
                 'project-id'
             ],
-            recursive=False,
-            returns_json=False
+            recursive=False
         )
 
     def test_refresh_token(self):

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 """Unit tests for oauth2client.contrib.gce."""
-import json
-import tempfile
-import unittest2
-import mock
 from datetime import datetime
 from datetime import timedelta
+import json
+import mock
+import tempfile
+import unittest2
 
 import httplib2
-from six.moves import http_client
 from oauth2client.client import HttpAccessTokenRefreshError
 from oauth2client.client import Credentials
 from oauth2client.client import save_to_well_known_file
@@ -30,6 +29,7 @@ from oauth2client.contrib.gce import _METADATA_ROOT
 from oauth2client.contrib.gce import _get_metadata
 from oauth2client.contrib.gce import AppAssertionCredentials
 from oauth2client.contrib.gce import MetadataServerHttpError
+from six.moves import http_client
 
 
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -59,7 +59,7 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
     @mock.patch('warnings.warn')
     @mock.patch(METADATA_SERVER, return_value=A_SERVICE_ACCOUNT)
     def test_constructor_with_matching_scopes(self, get_metadata, warn_mock):
-        scope = 'http://www.googleapis.com/auth/cloud-platform'
+        scope = 'https://www.googleapis.com/auth/cloud-platform'
         AppAssertionCredentials(scope=scope)
         warn_mock.assert_called_once_with(_SCOPES_WARNING)
 
@@ -159,9 +159,9 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
     @mock.patch('warnings.warn')
     @mock.patch(METADATA_SERVER, return_value=A_SERVICE_ACCOUNT)
     def test_create_scoped_valid(self, get_metadata, warn_mock):
-        scope = 'http://www.googleapis.com/auth/cloud-platform'
+        scope = 'https://www.googleapis.com/auth/cloud-platform'
         credentials = AppAssertionCredentials()
-        credentials.create_scoped(scope=scope)
+        credentials.create_scoped(scope)
         warn_mock.assert_called_once_with(_SCOPES_WARNING)
 
     # ERROR TESTS


### PR DESCRIPTION
This provides several much needed updates to GCE App Assertion Credentials
1. Properly populates token expiry
2. Retrieves credentials scopes from the metadata server
3. Allows credentials to use [custom service accounts](https://cloud.google.com/compute/docs/authentication#createcutomserviceaccount) by providing an optional email field
4. Implements serialization/deserialization for this email field
5. Provides a project_id property using metadata server in preparation for a pull request addressing #471 
