### PR TITLE
Adding more branch coverage in client.py.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -1628,7 +1628,7 @@ class AssertionCredentials(GoogleCredentials):
         raise NotImplementedError('This method is abstract.')
 
 
-def _RequireCryptoOrDie():
+def _require_crypto_or_die():
     """Ensure we have a crypto library, or throw CryptoUnavailableError.
 
     The oauth2client.crypt module requires either PyCrypto or PyOpenSSL
@@ -1667,7 +1667,7 @@ def verify_id_token(id_token, audience, http=None,
         oauth2client.crypt.AppIdentityError: if the JWT fails to verify.
         CryptoUnavailableError: if no crypto library is available.
     """
-    _RequireCryptoOrDie()
+    _require_crypto_or_die()
     if http is None:
         http = _cached_http
 


### PR DESCRIPTION
- Rename `_RequireCryptoOrDie()` to `_require_crypto_or_die()`
- Testing un-traversed GAE and GCE branches in
  `GoogleCredentials.get_application_default()`
- Missing env. var. branch in `_get_environment_variable_file`
- Missing APPDATA branch (on Windows) for `_get_well_known_file`
- Renaming some of the long ADC test names
- Adding test for `GoogleCredentials.get_application_default()`
  that actually uses the well-known file
- Branch in `GoogleCredentials.from_stream()` when filename is
  False-y
- Testing `_get_application_default_credential_GAE` and
  `_get_application_default_credential_GCE` (these just wrap
  circular imports at run time)
- Testing `_require_crypto_or_die`