### PR TITLE
Clarify control flow in LockedFile constructor

### DIFF
--- a/oauth2client/contrib/locked_file.py
+++ b/oauth2client/contrib/locked_file.py
@@ -345,17 +345,15 @@ class LockedFile(object):
             use_native_locking: bool, Whether or not fcntl/win32 locking is
                                 used.
         """
-        opener = None
-        if not opener and use_native_locking:
-            if _Win32Opener:
-                opener = _Win32Opener(filename, mode, fallback_mode)
+        if use_native_locking:
             if _FcntlOpener:
-                opener = _FcntlOpener(filename, mode, fallback_mode)
-
-        if not opener:
-            opener = _PosixOpener(filename, mode, fallback_mode)
-
-        self._opener = opener
+                self._opener = _FcntlOpener(filename, mode, fallback_mode)
+            elif _Win32Opener:
+                self._opener = _Win32Opener(filename, mode, fallback_mode)
+            else:
+                self._opener = _PosixOpener(filename, mode, fallback_mode)
+        else:
+            self._opener = _PosixOpener(filename, mode, fallback_mode)
 
     def filename(self):
         """Return the filename we were constructed with."""

--- a/tests/contrib/test_locked_file.py
+++ b/tests/contrib/test_locked_file.py
@@ -193,6 +193,7 @@ class TestLockedFile(unittest2.TestCase):
         opener_mock.assert_called_with('a_file', 'r+', 'r')
 
     @mock.patch('oauth2client.contrib.locked_file._Win32Opener')
+    @mock.patch.object(locked_file, '_FcntlOpener', None)
     def test_ctor_native_win32(self, opener_mock):
         instance = locked_file.LockedFile(
             'a_file', 'r+', 'r', use_native_locking=True)


### PR DESCRIPTION
Eliminate the unnecessary local field "opener" and ensure that
self._opener is assigned exactly once along every trajectory through
the constructor body.

I don't believe the `not opener` on line 349 of the old implementation could ever have been false, and if `_Win32Opener` and `_FcntlOpener` were both non-None then for calls with `use_native_locking` true the old implementation would have constructed an object just to throw it away. Right?