### PR TITLE
Adding test coverage for client.py.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -120,6 +120,7 @@ _DESIRED_METADATA_FLAVOR = 'Google'
 # Expose utcnow() at module level to allow for
 # easier testing (by replacing with a stub).
 _UTCNOW = datetime.datetime.utcnow
+_NOW = datetime.datetime.now
 
 
 class SETTINGS(object):
@@ -1862,7 +1863,7 @@ class DeviceFlowInfo(collections.namedtuple('DeviceFlowInfo', (
         })
         if 'expires_in' in response:
             kwargs['user_code_expiry'] = (
-                datetime.datetime.now() +
+                _NOW() +
                 datetime.timedelta(seconds=int(response['expires_in'])))
         return cls(**kwargs)
 
@@ -2201,4 +2202,4 @@ def flow_from_clientsecrets(filename, scope, redirect_uri=None,
             raise
     else:
         raise UnknownClientSecretsFlowError(
-            'This OAuth 2.0 flow is unsupported: %r' % client_type)
+            'This OAuth 2.0 flow is unsupported: %r' % (client_type,))

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -17,6 +17,8 @@
 import os
 import tempfile
 import time
+
+import mock
 import unittest2
 
 from .http_mock import HttpMockSequence
@@ -126,6 +128,20 @@ class CryptTests(unittest2.TestCase):
         contents = verify_id_token(
             jwt, 'some_audience_address@testing.gserviceaccount.com',
             http=http)
+        self.assertEqual('billy bob', contents['user'])
+        self.assertEqual('data', contents['metadata']['meta'])
+
+    def test_verify_id_token_with_certs_uri_default_http(self):
+        jwt = self._create_signed_jwt()
+
+        http = HttpMockSequence([
+            ({'status': '200'}, datafile('certs.json')),
+        ])
+
+        with mock.patch('oauth2client.client._cached_http', new=http):
+            contents = verify_id_token(
+                jwt, 'some_audience_address@testing.gserviceaccount.com')
+
         self.assertEqual('billy bob', contents['user'])
         self.assertEqual('data', contents['metadata']['meta'])
 


### PR DESCRIPTION
- `DeviceFlowInfo` (and using datetime now patch).
- Corner cases for `step1_get_authorize_url` and
  `step2_exchange`
- Failure cases for `flow_from_clientsecrets`
- `verify_id_token` when the cached HTTP is used (i.e.
  the default argument)
