### PR TITLE
Getting client.py to 100% coverage.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -120,6 +120,7 @@ _DESIRED_METADATA_FLAVOR = 'Google'
 # Expose utcnow() at module level to allow for
 # easier testing (by replacing with a stub).
 _UTCNOW = datetime.datetime.utcnow
+_NOW = datetime.datetime.now
 
 
 class SETTINGS(object):
@@ -1862,7 +1863,7 @@ class DeviceFlowInfo(collections.namedtuple('DeviceFlowInfo', (
         })
         if 'expires_in' in response:
             kwargs['user_code_expiry'] = (
-                datetime.datetime.now() +
+                _NOW() +
                 datetime.timedelta(seconds=int(response['expires_in'])))
         return cls(**kwargs)
 
@@ -2201,4 +2202,4 @@ def flow_from_clientsecrets(filename, scope, redirect_uri=None,
             raise
     else:
         raise UnknownClientSecretsFlowError(
-            'This OAuth 2.0 flow is unsupported: %r' % client_type)
+            'This OAuth 2.0 flow is unsupported: %r' % (client_type,))

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -2021,17 +2021,17 @@ class OAuth2WebServerFlow(Flow):
         if resp.status == http_client.OK:
             try:
                 flow_info = json.loads(content)
-            except ValueError as e:
+            except ValueError as exc:
                 raise OAuth2DeviceCodeError(
                     'Could not parse server response as JSON: "%s", '
-                    'error: "%s"' % (content, e))
+                    'error: "%s"' % (content, exc))
             return DeviceFlowInfo.FromResponse(flow_info)
         else:
-            error_msg = 'Invalid response %s.' % resp.status
+            error_msg = 'Invalid response %s.' % (resp.status,)
             try:
-                d = json.loads(content)
-                if 'error' in d:
-                    error_msg += ' Error: %s' % d['error']
+                error_dict = json.loads(content)
+                if 'error' in error_dict:
+                    error_msg += ' Error: %s' % (error_dict['error'],)
             except ValueError:
                 # Couldn't decode a JSON response, stick with the
                 # default message.

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -17,6 +17,8 @@
 import os
 import tempfile
 import time
+
+import mock
 import unittest2
 
 from .http_mock import HttpMockSequence
@@ -126,6 +128,20 @@ class CryptTests(unittest2.TestCase):
         contents = verify_id_token(
             jwt, 'some_audience_address@testing.gserviceaccount.com',
             http=http)
+        self.assertEqual('billy bob', contents['user'])
+        self.assertEqual('data', contents['metadata']['meta'])
+
+    def test_verify_id_token_with_certs_uri_default_http(self):
+        jwt = self._create_signed_jwt()
+
+        http = HttpMockSequence([
+            ({'status': '200'}, datafile('certs.json')),
+        ])
+
+        with mock.patch('oauth2client.client._cached_http', new=http):
+            contents = verify_id_token(
+                jwt, 'some_audience_address@testing.gserviceaccount.com')
+
         self.assertEqual('billy bob', contents['user'])
         self.assertEqual('data', contents['metadata']['meta'])
 


### PR DESCRIPTION
In particular:
- `step1_get_device_and_user_codes`
- `step2_exchange` with device info
- Making explicit the `code=` argument in calls to
  `step2_exchange` in tests
- `flow_from_clientsecrets` branches with revoke and
  device URI optional args

----

**NOTE**: Has #485 as diffbase.