### PR TITLE
Replacing now() with utcnow() in device info code.

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -120,7 +120,6 @@ _DESIRED_METADATA_FLAVOR = 'Google'
 # Expose utcnow() at module level to allow for
 # easier testing (by replacing with a stub).
 _UTCNOW = datetime.datetime.utcnow
-_NOW = datetime.datetime.now
 
 
 class SETTINGS(object):
@@ -1863,7 +1862,7 @@ class DeviceFlowInfo(collections.namedtuple('DeviceFlowInfo', (
         })
         if 'expires_in' in response:
             kwargs['user_code_expiry'] = (
-                _NOW() +
+                _UTCNOW() +
                 datetime.timedelta(seconds=int(response['expires_in'])))
         return cls(**kwargs)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2337,8 +2337,8 @@ class TestDeviceFlowInfo(unittest2.TestCase):
         with self.assertRaises(client.OAuth2DeviceCodeError):
             DeviceFlowInfo.FromResponse(response)
 
-    @mock.patch('oauth2client.client._NOW')
-    def test_FromResponse_with_expires_in(self, dt_now):
+    @mock.patch('oauth2client.client._UTCNOW')
+    def test_FromResponse_with_expires_in(self, utcnow):
         expires_in = 23
         response = {
             'device_code': self.DEVICE_CODE,
@@ -2348,7 +2348,7 @@ class TestDeviceFlowInfo(unittest2.TestCase):
         }
         now = datetime.datetime(1999, 1, 1, 12, 30, 27)
         expire = datetime.datetime(1999, 1, 1, 12, 30, 27 + expires_in)
-        dt_now.return_value = now
+        utcnow.return_value = now
 
         result = DeviceFlowInfo.FromResponse(response)
         expected_result = DeviceFlowInfo(self.DEVICE_CODE, self.USER_CODE,


### PR DESCRIPTION
This change was discussed in #485.
