### PR TITLE
Get django_orm to 100% coverage

### DIFF
--- a/oauth2client/contrib/django_orm.py
+++ b/oauth2client/contrib/django_orm.py
@@ -109,7 +109,7 @@ class Storage(BaseStorage):
     """Store and retrieve a single credential to and from the Django datastore.
 
     This Storage helper presumes the Credentials
-    have been stored as a CredenialsField
+    have been stored as a CredentialsField
     on a db model class.
     """
 

--- a/tests/contrib/test_django_orm.py
+++ b/tests/contrib/test_django_orm.py
@@ -38,6 +38,8 @@ import django
 django.setup()
 from django.apps import AppConfig
 
+import mock
+
 
 class DjangoOrmTestApp(AppConfig):
     """App Config for Django Helper."""
@@ -138,26 +140,110 @@ class TestStorage(unittest.TestCase):
         refresh_token = '1/0/a.df219fjls0'
         token_expiry = datetime.datetime.utcnow()
         user_agent = 'refresh_checker/1.0'
+
         self.credentials = OAuth2Credentials(
             access_token, client_id, client_secret,
             refresh_token, token_expiry, GOOGLE_TOKEN_URI,
             user_agent)
 
+        self.key_name = 'id'
+        self.key_value = '1'
+        self.property_name = 'credentials'
+
     def test_constructor(self):
-        key_name = 'foo'
-        key_value = 'bar'
-        property_name = 'credentials'
-        storage = Storage(FakeCredentialsModel, key_name,
-                          key_value, property_name)
+        storage = Storage(FakeCredentialsModel, self.key_name,
+                          self.key_value, self.property_name)
 
         self.assertEqual(storage.model_class, FakeCredentialsModel)
-        self.assertEqual(storage.key_name, key_name)
-        self.assertEqual(storage.key_value, key_value)
-        self.assertEqual(storage.property_name, property_name)
+        self.assertEqual(storage.key_name, self.key_name)
+        self.assertEqual(storage.key_value, self.key_value)
+        self.assertEqual(storage.property_name, self.property_name)
+
+    @mock.patch('django.db.models')
+    def test_locked_get(self, djangoModel):
+        fake_model_with_credentials = FakeCredentialsModelMock()
+        entities = [
+            fake_model_with_credentials
+        ]
+        filter_mock = mock.Mock(return_value=entities)
+        object_mock = mock.Mock()
+        object_mock.filter = filter_mock
+        FakeCredentialsModelMock.objects = object_mock
+
+        storage = Storage(FakeCredentialsModelMock, self.key_name,
+                          self.key_value, self.property_name)
+        credential = storage.locked_get()
+        self.assertEqual(
+            credential, fake_model_with_credentials.credentials)
+
+    @mock.patch('django.db.models')
+    def test_locked_put(self, djangoModel):
+        storage = Storage(FakeCredentialsModelMock, self.key_name,
+                          self.key_value, self.property_name)
+        storage.locked_put(self.credentials)
+
+    @mock.patch('django.db.models')
+    def test_locked_put_with_overwite(self, djangoModel):
+        get_or_create_mock = mock.Mock()
+        fake_credentials = FakeCredentialsModelMock()
+        get_or_create_mock.return_value = (fake_credentials, True)
+
+        object_mock = mock.Mock()
+        object_mock.get_or_create = get_or_create_mock
+        FakeCredentialsModelMock.objects.get_or_create = get_or_create_mock
+
+        storage = Storage(FakeCredentialsModelMock, self.key_name,
+                          self.key_value, self.property_name)
+        storage.locked_put(self.credentials, True)
+        self.assertTrue(fake_credentials.saved)
+
+    @mock.patch('django.db.models')
+    def test_locked_delete(self, djangoModel):
+
+        class FakeEntities(object):
+            def __init__(self):
+                self.deleted = False
+
+            def delete(self):
+                self.deleted = True
+
+        fake_entities = FakeEntities()
+        entities = fake_entities
+
+        filter_mock = mock.Mock(return_value=entities)
+        object_mock = mock.Mock()
+        object_mock.filter = filter_mock
+        FakeCredentialsModelMock.objects = object_mock
+        storage = Storage(FakeCredentialsModelMock, self.key_name,
+                          self.key_value, self.property_name)
+        storage.locked_delete()
+        self.assertTrue(fake_entities.deleted)
+
+
+class CredentialWithSetStore(CredentialsField):
+
+    def __init__(self):
+        self.model = CredentialWithSetStore
+
+    def set_store(self, storage):
+        pass
 
 
 class FakeCredentialsModel(models.Model):
     credentials = CredentialsField()
+
+
+class FakeCredentialsModelMock(object):
+
+    def __init__(self, *args, **kwargs):
+        self.model = FakeCredentialsModelMock
+        self.saved = False
+        self.deleted = False
+
+    def save(self):
+        self.saved = True
+
+    credentials = CredentialWithSetStore()
 
 
 if __name__ == '__main__':  # pragma: NO COVER


### PR DESCRIPTION
This is a first-pass at "shortest path to 100% coverage". It aggressively mocks out Django model methods and doesn't assert all too much. I am hesitant to invest too much in asserting more since I want to refactor this whole file anyway and merge it into django_util. 

If we want to mock out Django models less, we would need to figure out how to rig up the Django test database for the tests which I think is not what people want (although it would probably be significantly easier with something like Jon's nox).
