### PR TITLE
Require 100% line coverage for tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ deps = {[testenv]basedeps}
 basepython = {[coverbase]basepython}
 commands =
     {[coverbase]commands}
-    coverage report --show-missing --fail-under 80
+    coverage report --show-missing --cover-min-percentage=100
 deps =
     {[coverbase]deps}
 


### PR DESCRIPTION
I also made this required on coveralls.io.

![screen_shot_008](https://cloud.githubusercontent.com/assets/520669/14399864/f8fdba6e-fda5-11e5-8171-26f0caa4eb1d.png)

----

This will be "broken" until @waprin wraps up the branch misses in `django_orm.py`, so I can just wait to merge this (and rebase) once he is done.