### PR TITLE
Release v2.0.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v2.0.2
+
+* Fix issue where `flask_util.UserOAuth2.required` would accept expired credentials (#452).
+* Fix issue where `flask_util` would fill the session with `Flow` objects (#498).
+* Fix issue with Python 3 binary strings in `Flow.step2_exchange` (#446).
+* Improve test coverage to 100%.
+
 ## v2.0.1
 
 * Making scopes optional on Google Compute Engine `AppAssertionCredentials`

--- a/oauth2client/__init__.py
+++ b/oauth2client/__init__.py
@@ -14,7 +14,7 @@
 
 """Client library for using OAuth2, especially with Google APIs."""
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 GOOGLE_AUTH_URI = 'https://accounts.google.com/o/oauth2/v2/auth'
 GOOGLE_DEVICE_URI = 'https://accounts.google.com/o/oauth2/device/code'


### PR DESCRIPTION
`git log v2.0.1..HEAD | grep 'Merge pull request ' | awk -F ' ' '{print $4 $5}' | sort` yields:
#446 - Python 3 fixes for step2_exchange.
#452 - flask_util requests new credentials when expired.
#457 - Typo
#460 - Coverage
#462 - Coverage
#464 - Coverage
#467 - Coverage
#477 - Coverage
#478 - Moved openers
#479 - Coverage
#481 - Coverage
#482 - Coverage
#483 - Coverage
#486 - Coverage
#490 - Coverage
#492 - Coverage
#493 - Coverage
#495 - Coverage
#496 - Coverage
#498 - Fix flask_util session thrashing
#500 - Fix flask_util docstrings
#457, #478, and #500 were not included in release notes.
