### PR TITLE
django 1.10 fix

### DIFF
--- a/oauth2client/contrib/django_orm.py
+++ b/oauth2client/contrib/django_orm.py
@@ -31,7 +31,7 @@ from oauth2client.client import Storage as BaseStorage
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
 
-class CredentialsField(six.with_metaclass(models.SubfieldBase, models.Field)):
+class CredentialsField(models.Field):
 
     def __init__(self, *args, **kwargs):
         if 'null' not in kwargs:
@@ -40,6 +40,11 @@ class CredentialsField(six.with_metaclass(models.SubfieldBase, models.Field)):
 
     def get_internal_type(self):
         return 'TextField'
+
+    def from_db_value(self, value, expression, connection, context):
+        if value is None:
+            return None
+        return pickle.loads(base64.b64decode(smart_bytes(value)))
 
     def to_python(self, value):
         if value is None:
@@ -68,7 +73,7 @@ class CredentialsField(six.with_metaclass(models.SubfieldBase, models.Field)):
         return self.get_prep_value(value)
 
 
-class FlowField(six.with_metaclass(models.SubfieldBase, models.Field)):
+class FlowField(models.Field):
 
     def __init__(self, *args, **kwargs):
         if 'null' not in kwargs:
@@ -77,6 +82,11 @@ class FlowField(six.with_metaclass(models.SubfieldBase, models.Field)):
 
     def get_internal_type(self):
         return 'TextField'
+
+    def from_db_value(self, value, expression, connection, context):
+        if value is None:
+            return None
+        return pickle.loads(base64.b64decode(value))
 
     def to_python(self, value):
         if value is None:

--- a/oauth2client/contrib/django_orm.py
+++ b/oauth2client/contrib/django_orm.py
@@ -42,9 +42,7 @@ class CredentialsField(models.Field):
         return 'TextField'
 
     def from_db_value(self, value, expression, connection, context):
-        if value is None:
-            return None
-        return pickle.loads(base64.b64decode(smart_bytes(value)))
+        return self.to_python(value)
 
     def to_python(self, value):
         if value is None:
@@ -84,9 +82,7 @@ class FlowField(models.Field):
         return 'TextField'
 
     def from_db_value(self, value, expression, connection, context):
-        if value is None:
-            return None
-        return pickle.loads(base64.b64decode(value))
+        return self.to_python(value)
 
     def to_python(self, value):
         if value is None:


### PR DESCRIPTION
```python
/usr/local/lib/python2.7/dist-packages/six.py:808: RemovedInDjango110Warning: SubfieldBase has been deprecated. Use Field.from_db_value instead.
  return meta(name, bases, d)

/usr/local/lib/python2.7/dist-packages/six.py:808: RemovedInDjango110Warning: SubfieldBase has been deprecated. Use Field.from_db_value instead.
  return meta(name, bases, d)
```