### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ You can sign these electronically (just scroll to the bottom). After that,
 we'll be able to accept your pull requests.
 
 [1]: https://github.com/google/oauth2client
-[2]: https://tox.readthedocs.org/en/latest/
+[2]: https://tox.readthedocs.io/en/latest/
 [3]: https://cloud.google.com/storage/docs/authentication#generating-a-private-key
 [4]: https://developers.google.com/open-source/cla/individual
 [5]: https://developers.google.com/open-source/cla/corporate
@@ -199,6 +199,6 @@ we'll be able to accept your pull requests.
 [10]: #fork-oauth2client
 [11]: #include-tests
 [12]: #make-the-pull-request
-[13]: http://oauth2client.readthedocs.org/en/latest/#using-pypy
+[13]: https://oauth2client.readthedocs.io/en/latest/#using-pypy
 [14]: https://docs.djangoproject.com/en/1.7/faq/install/#what-python-version-can-i-use-with-django
 [15]: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/google/oauth2client.svg?branch=master)](https://travis-ci.org/google/oauth2client)
 [![Coverage Status](https://coveralls.io/repos/google/oauth2client/badge.svg?branch=master&service=github)](https://coveralls.io/github/google/oauth2client?branch=master)
-[![Documentation Status](https://readthedocs.org/projects/oauth2client/badge/?version=latest)](http://oauth2client.readthedocs.org/)
+[![Documentation Status](https://readthedocs.org/projects/oauth2client/badge/?version=latest)](https://oauth2client.readthedocs.io/)
 
 This is a client library for accessing resources protected by OAuth 2.0.
 
@@ -26,4 +26,4 @@ Supported Python Versions
 We support Python 2.6, 2.7, 3.3+. More information [in the docs][2].
 
 [1]: https://github.com/google/oauth2client/blob/master/CONTRIBUTING.md
-[2]: http://oauth2client.readthedocs.org/#supported-python-versions
+[2]: https://oauth2client.readthedocs.io/#supported-python-versions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ import sys
 import mock
 
 # See
-# (http://read-the-docs.readthedocs.org/en/latest/faq.html#\
+# (https://read-the-docs.readthedocs.io/en/latest/faq.html#\
 #  i-get-import-errors-on-libraries-that-depend-on-c-modules)
 
 class Mock(mock.Mock):


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
