### PR TITLE
Handle OSError cases in multistore_file

### DIFF
--- a/oauth2client/contrib/multistore_file.py
+++ b/oauth2client/contrib/multistore_file.py
@@ -298,7 +298,7 @@ class _MultiStore(object):
         self._thread_lock.acquire()
         try:
             self._file.open_and_lock()
-        except IOError as e:
+        except (IOError, OSError) as e:
             if e.errno == errno.ENOSYS:
                 logger.warn('File system does not support locking the '
                             'credentials file.')


### PR DESCRIPTION
This change fixes an exception in multistore_file that occurs when
the lock file is under conection. Windows may raise an OSError in
this case, where other platforms typically raise in IOError.
