### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+
+## v2.2.0
+
+* Added support to override `token_uri` and `revoke_uri` in `oauth2client.service_account.ServiceAccountCredentials`. (#510)
+* `oauth2client.contrib.multistore_file` now handles `OSError` in addition to `IOError` because Windows may raise `OSError` where other platforms will raise `IOError`.
+* `oauth2client.contrib.django_util` and `oauth2client.contrib.django_orm` have been updated to support Django 1.8 - 1.10. Versions of Django below 1.8 will not work with these modules.
+
 ## v2.1.0
 
 * Add basic support for JWT access credentials. (#503)

--- a/oauth2client/__init__.py
+++ b/oauth2client/__init__.py
@@ -14,7 +14,7 @@
 
 """Client library for using OAuth2, especially with Google APIs."""
 
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 
 GOOGLE_AUTH_URI = 'https://accounts.google.com/o/oauth2/v2/auth'
 GOOGLE_DEVICE_URI = 'https://accounts.google.com/o/oauth2/device/code'


### PR DESCRIPTION
`git log v2.1.0..HEAD` yields:

```
commit b55744061f91fe68cf074e0fd07b0964129ce811
Author: thobrla <thobrla@google.com>
Date:   Tue Jun 7 09:36:58 2016 -0700

    Support token_uri and revoke_uri in ServiceAccountCredentials (#510)

    This change adds support for custom authorization token
    and revocation URIs in the various ServiceAccountCredentials
    factory methods.

commit f5ae963b7c268c33bfa711d687258cff8c61205a
Author: thobrla <thobrla@google.com>
Date:   Mon Jun 6 14:15:53 2016 -0700

    Handle OSError cases in multistore_file (#517)

    This change fixes an exception in multistore_file that occurs when
    the lock file is under conection. Windows may raise an OSError in
    this case, where other platforms typically raise in IOError.

commit a3cbf51bc9dcb9494bb657ac5bc1749a80bc2973
Author: Bill Prin <waprin@gmail.com>
Date:   Mon Jun 6 12:42:18 2016 -0700

    django 1.10 fix (#516)

    Fix django packages for 1.10, add docs noting django 1.8+ support.
```
