### PR TITLE
Remove httplib2 imports from non-transport modules.

### DIFF
--- a/oauth2client/contrib/_metadata.py
+++ b/oauth2client/contrib/_metadata.py
@@ -20,7 +20,6 @@ See https://cloud.google.com/compute/docs/metadata
 import datetime
 import json
 
-import httplib2
 from six.moves import http_client
 from six.moves.urllib import parse as urlparse
 
@@ -51,7 +50,8 @@ def get(http_request, path, root=METADATA_ROOT, recursive=None):
         A dictionary if the metadata server returns JSON, otherwise a string.
 
     Raises:
-        httplib2.Httplib2Error if an error corrured while retrieving metadata.
+        http_client.HTTPException if an error corrured while
+        retrieving metadata.
     """
     url = urlparse.urljoin(root, path)
     url = util._add_query_parameter(url, 'recursive', recursive)
@@ -68,7 +68,7 @@ def get(http_request, path, root=METADATA_ROOT, recursive=None):
         else:
             return decoded
     else:
-        raise httplib2.HttpLib2Error(
+        raise http_client.HTTPException(
             'Failed to retrieve {0} from the Google Compute Engine'
             'metadata service. Response:\n{1}'.format(url, response))
 

--- a/oauth2client/contrib/appengine.py
+++ b/oauth2client/contrib/appengine.py
@@ -29,12 +29,12 @@ from google.appengine.api import memcache
 from google.appengine.api import users
 from google.appengine.ext import db
 from google.appengine.ext.webapp.util import login_required
-import httplib2
 import webapp2 as webapp
 
 import oauth2client
 from oauth2client import client
 from oauth2client import clientsecrets
+from oauth2client import transport
 from oauth2client import util
 from oauth2client.contrib import xsrfutil
 
@@ -742,7 +742,8 @@ class OAuth2Decorator(object):
             *args: Positional arguments passed to httplib2.Http constructor.
             **kwargs: Positional arguments passed to httplib2.Http constructor.
         """
-        return self.credentials.authorize(httplib2.Http(*args, **kwargs))
+        return self.credentials.authorize(
+            transport.get_http_object(*args, **kwargs))
 
     @property
     def callback_path(self):

--- a/oauth2client/contrib/django_util/__init__.py
+++ b/oauth2client/contrib/django_util/__init__.py
@@ -228,10 +228,10 @@ import importlib
 import django.conf
 from django.core import exceptions
 from django.core import urlresolvers
-import httplib2
 from six.moves.urllib import parse
 
 from oauth2client import clientsecrets
+from oauth2client import transport
 from oauth2client.contrib import dictionary_storage
 from oauth2client.contrib.django_util import storage
 
@@ -470,8 +470,7 @@ class UserOAuth2(object):
 
     @property
     def http(self):
-        """Helper method to create an HTTP client authorized with OAuth2
-        credentials."""
+        """Helper: create HTTP client authorized with OAuth2 credentials."""
         if self.has_credentials():
-            return self.credentials.authorize(httplib2.Http())
+            return self.credentials.authorize(transport.get_http_object())
         return None

--- a/oauth2client/contrib/flask_util.py
+++ b/oauth2client/contrib/flask_util.py
@@ -179,11 +179,11 @@ try:
 except ImportError:  # pragma: NO COVER
     raise ImportError('The flask utilities require flask 0.9 or newer.')
 
-import httplib2
 import six.moves.http_client as httplib
 
 from oauth2client import client
 from oauth2client import clientsecrets
+from oauth2client import transport
 from oauth2client.contrib import dictionary_storage
 
 
@@ -553,4 +553,5 @@ class UserOAuth2(object):
         """
         if not self.credentials:
             raise ValueError('No credentials available.')
-        return self.credentials.authorize(httplib2.Http(*args, **kwargs))
+        return self.credentials.authorize(
+            transport.get_http_object(*args, **kwargs))

--- a/oauth2client/contrib/gce.py
+++ b/oauth2client/contrib/gce.py
@@ -20,7 +20,7 @@ Utilities for making it easier to use OAuth 2.0 on Google Compute Engine.
 import logging
 import warnings
 
-import httplib2
+from six.moves import http_client
 
 from oauth2client import client
 from oauth2client.contrib import _metadata
@@ -134,8 +134,8 @@ class AppAssertionCredentials(client.AssertionCredentials):
             self._retrieve_info(http_request)
             self.access_token, self.token_expiry = _metadata.get_token(
                 http_request, service_account=self.service_account_email)
-        except httplib2.HttpLib2Error as e:
-            raise client.HttpAccessTokenRefreshError(str(e))
+        except http_client.HTTPException as err:
+            raise client.HttpAccessTokenRefreshError(str(err))
 
     @property
     def serialization_data(self):

--- a/oauth2client/transport.py
+++ b/oauth2client/transport.py
@@ -58,13 +58,19 @@ def get_cached_http():
     return _CACHED_HTTP
 
 
-def get_http_object():
+def get_http_object(*args, **kwargs):
     """Return a new HTTP object.
+
+    Args:
+        *args: tuple, The positional arguments to be passed when
+               contructing a new HTTP object.
+        **kwargs: dict, The keyword arguments to be passed when
+                  contructing a new HTTP object.
 
     Returns:
         httplib2.Http, an HTTP object.
     """
-    return httplib2.Http()
+    return httplib2.Http(*args, **kwargs)
 
 
 def _initialize_headers(headers):

--- a/tests/contrib/test_metadata.py
+++ b/tests/contrib/test_metadata.py
@@ -62,7 +62,7 @@ class TestMetadata(unittest2.TestCase):
     def test_get_failure(self):
         http_request = request_mock(
             http_client.NOT_FOUND, 'text/html', '<p>Error</p>')
-        with self.assertRaises(httplib2.HttpLib2Error):
+        with self.assertRaises(http_client.HTTPException):
             _metadata.get(http_request, PATH)
 
         http_request.assert_called_once_with(EXPECTED_URL, **EXPECTED_KWARGS)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -52,6 +52,13 @@ class Test_get_http_object(unittest2.TestCase):
     def test_it(self, http_klass):
         result = transport.get_http_object()
         self.assertEqual(result, http_klass.return_value)
+        http_klass.assert_called_once_with()
+
+    @mock.patch.object(httplib2, 'Http', return_value=object())
+    def test_with_args(self, http_klass):
+        result = transport.get_http_object(1, 2, foo='bar')
+        self.assertEqual(result, http_klass.return_value)
+        http_klass.assert_called_once_with(1, 2, foo='bar')
 
 
 class Test__initialize_headers(unittest2.TestCase):


### PR DESCRIPTION
Now all usage of `httplib2` is concentrated in tests and in the `oauth2client.transport` module. This does not yet cover all behavior that implicitly relies on `httplib2` in these modules, so there is still work to be done.

---

``` bash
$ git grep import | grep httplib2
oauth2client/transport.py:import httplib2
samples/oauth2_for_devices.py:import httplib2
scripts/run_gce_system_tests.py:import httplib2
scripts/run_system_tests.py:import httplib2
tests/contrib/test_appengine.py:import httplib2
tests/contrib/test_flask_util.py:import httplib2
tests/contrib/test_gce.py:import httplib2
tests/contrib/test_metadata.py:import httplib2
tests/http_mock.py:import httplib2
tests/test_client.py:import httplib2
tests/test_service_account.py:import httplib2
tests/test_transport.py:import httplib2
```
