### PR TITLE
Removes usage of httplib2 in unit tests.

### DIFF
--- a/tests/contrib/test_flask_util.py
+++ b/tests/contrib/test_flask_util.py
@@ -229,8 +229,8 @@ class FlaskOAuth2Tests(unittest2.TestCase):
             with mock.patch(
                     'oauth2client.transport.get_http_object') as new_http:
                 # Set-up mock.
-                new_http.return_value = http = http_mock.HttpMock(
-                    data=DEFAULT_RESP)
+                http = http_mock.HttpMock(data=DEFAULT_RESP)
+                new_http.return_value = http
                 # Run tests.
                 state = self._setup_callback_state(client)
 

--- a/tests/contrib/test_flask_util.py
+++ b/tests/contrib/test_flask_util.py
@@ -19,7 +19,6 @@ import json
 import logging
 
 import flask
-import httplib2
 import mock
 import six.moves.http_client as httplib
 import six.moves.urllib.parse as urlparse
@@ -29,39 +28,20 @@ import oauth2client
 from oauth2client import client
 from oauth2client import clientsecrets
 from oauth2client.contrib import flask_util
+from .. import http_mock
 
 
 __author__ = 'jonwayne@google.com (Jon Wayne Parrott)'
 
 
-class Http2Mock(object):
-    """Mock httplib2.Http for code exchange / refresh"""
-
-    def __init__(self, status=httplib.OK, **kwargs):
-        self.status = status
-        self.content = {
-            'access_token': 'foo_access_token',
-            'refresh_token': 'foo_refresh_token',
-            'expires_in': 3600,
-            'extra': 'value',
-        }
-        self.content.update(kwargs)
-
-    def request(self, token_uri, method, body, headers, *args, **kwargs):
-        self.body = body
-        self.headers = headers
-        return (self, json.dumps(self.content).encode('utf-8'))
-
-    def __enter__(self):
-        self.httplib2_orig = httplib2.Http
-        httplib2.Http = self
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        httplib2.Http = self.httplib2_orig
-
-    def __call__(self, *args, **kwargs):
-        return self
+DEFAULT_RESP = """\
+{
+    "access_token": "foo_access_token",
+    "expires_in": 3600,
+    "extra": "value",
+    "refresh_token": "foo_refresh_token"
+}
+"""
 
 
 class FlaskOAuth2Tests(unittest2.TestCase):
@@ -246,7 +226,12 @@ class FlaskOAuth2Tests(unittest2.TestCase):
     def test_callback_view(self):
         self.oauth2.storage = mock.Mock()
         with self.app.test_client() as client:
-            with Http2Mock() as http:
+            with mock.patch(
+                    'oauth2client.transport.get_http_object') as new_http:
+                # Set-up mock.
+                new_http.return_value = http = http_mock.HttpMock(
+                    data=DEFAULT_RESP)
+                # Run tests.
                 state = self._setup_callback_state(client)
 
                 response = client.get(
@@ -257,6 +242,9 @@ class FlaskOAuth2Tests(unittest2.TestCase):
                 self.assertIn(self.oauth2.client_secret, http.body)
                 self.assertIn('codez', http.body)
                 self.assertTrue(self.oauth2.storage.put.called)
+
+                # Check the mocks were called.
+                new_http.assert_called_once_with()
 
     def test_authorize_callback(self):
         self.oauth2.authorize_callback = mock.Mock()
@@ -296,10 +284,19 @@ class FlaskOAuth2Tests(unittest2.TestCase):
         with self.app.test_client() as client:
             state = self._setup_callback_state(client)
 
-            with Http2Mock(status=httplib.INTERNAL_SERVER_ERROR):
+            with mock.patch(
+                    'oauth2client.transport.get_http_object') as new_http:
+                # Set-up mock.
+                new_http.return_value = http_mock.HttpMock(
+                    headers={'status': httplib.INTERNAL_SERVER_ERROR},
+                    data=DEFAULT_RESP)
+                # Run tests.
                 response = client.get(
                     '/oauth2callback?state={0}&code=codez'.format(state))
                 self.assertEqual(response.status_code, httplib.BAD_REQUEST)
+
+                # Check the mocks were called.
+                new_http.assert_called_once_with()
 
         # Invalid state json
         with self.app.test_client() as client:
@@ -495,7 +492,10 @@ class FlaskOAuth2Tests(unittest2.TestCase):
     def test_incremental_auth_exchange(self):
         self._create_incremental_auth_app()
 
-        with Http2Mock():
+        with mock.patch('oauth2client.transport.get_http_object') as new_http:
+            # Set-up mock.
+            new_http.return_value = http_mock.HttpMock(data=DEFAULT_RESP)
+            # Run tests.
             with self.app.test_client() as client:
                 state = self._setup_callback_state(
                     client,
@@ -511,16 +511,21 @@ class FlaskOAuth2Tests(unittest2.TestCase):
                 self.assertTrue(
                     credentials.has_scopes(['email', 'one', 'two']))
 
+            # Check the mocks were called.
+            new_http.assert_called_once_with()
+
     def test_refresh(self):
+        token_val = 'new_token'
+        json_resp = '{"access_token": "%s"}' % (token_val,)
+        http = http_mock.HttpMock(data=json_resp)
         with self.app.test_request_context():
             with mock.patch('flask.session'):
                 self.oauth2.storage.put(self._generate_credentials())
 
-                self.oauth2.credentials.refresh(
-                    Http2Mock(access_token='new_token'))
+                self.oauth2.credentials.refresh(http)
 
                 self.assertEqual(
-                    self.oauth2.storage.get().access_token, 'new_token')
+                    self.oauth2.storage.get().access_token, token_val)
 
     def test_delete(self):
         with self.app.test_request_context():

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -17,7 +17,6 @@
 import datetime
 import json
 
-import httplib2
 import mock
 from six.moves import http_client
 from tests.contrib.test_metadata import request_mock
@@ -129,12 +128,12 @@ class AppAssertionCredentialsTests(unittest2.TestCase):
                                          service_account='default')
 
     @mock.patch('oauth2client.contrib._metadata.get_service_account_info',
-                side_effect=httplib2.HttpLib2Error('No Such Email'))
+                side_effect=http_client.HTTPException('No Such Email'))
     def test_retrieve_scopes_bad_email(self, metadata):
         http_request = mock.MagicMock()
         http_mock = mock.MagicMock(request=http_request)
         credentials = gce.AppAssertionCredentials(email='b@example.com')
-        with self.assertRaises(httplib2.HttpLib2Error):
+        with self.assertRaises(http_client.HTTPException):
             credentials.retrieve_scopes(http_mock)
 
         metadata.assert_called_once_with(http_request,

--- a/tests/contrib/test_metadata.py
+++ b/tests/contrib/test_metadata.py
@@ -32,9 +32,9 @@ EXPECTED_KWARGS = dict(headers=_metadata.METADATA_HEADERS)
 
 
 def request_mock(status, content_type, content):
-    resp = http_mock.ResponseMock(
+    response = http_mock.ResponseMock(
         {'status': status, 'content-type': content_type})
-    return mock.Mock(return_value=(resp, content.encode('utf-8')))
+    return mock.Mock(return_value=(response, content.encode('utf-8')))
 
 
 class TestMetadata(unittest2.TestCase):

--- a/tests/contrib/test_metadata.py
+++ b/tests/contrib/test_metadata.py
@@ -15,12 +15,13 @@
 import datetime
 import json
 
-import httplib2
 import mock
 from six.moves import http_client
 import unittest2
 
 from oauth2client.contrib import _metadata
+from .. import http_mock
+
 
 PATH = 'instance/service-accounts/default'
 DATA = {'foo': 'bar'}
@@ -31,12 +32,9 @@ EXPECTED_KWARGS = dict(headers=_metadata.METADATA_HEADERS)
 
 
 def request_mock(status, content_type, content):
-    return mock.MagicMock(return_value=(
-        httplib2.Response(
-            {'status': status, 'content-type': content_type}
-        ),
-        content.encode('utf-8')
-    ))
+    resp = http_mock.ResponseMock(
+        {'status': status, 'content-type': content_type})
+    return mock.Mock(return_value=(resp, content.encode('utf-8')))
 
 
 class TestMetadata(unittest2.TestCase):

--- a/tests/http_mock.py
+++ b/tests/http_mock.py
@@ -15,6 +15,9 @@
 """HTTP helpers mock functionality."""
 
 
+from six.moves import http_client
+
+
 class ResponseMock(dict):
     """Mock HTTP response"""
 
@@ -22,7 +25,7 @@ class ResponseMock(dict):
         if vals is None:
             vals = {}
         self.update(vals)
-        self.status = int(self.get('status', 200))
+        self.status = int(self.get('status', http_client.OK))
 
 
 class HttpMock(object):
@@ -35,7 +38,7 @@ class HttpMock(object):
             headers: dict, header to return with response
         """
         if headers is None:
-            headers = {'status': '200'}
+            headers = {'status': http_client.OK}
         self.data = data
         self.response_headers = headers
         self.headers = None

--- a/tests/http_mock.py
+++ b/tests/http_mock.py
@@ -12,17 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Copy of googleapiclient.http's mock functionality."""
+"""HTTP helpers mock functionality."""
 
-import httplib2
 
-# TODO(craigcitro): Find a cleaner way to share this code with googleapiclient.
+class ResponseMock(dict):
+    """Mock HTTP response"""
+
+    def __init__(self, vals=None):
+        if vals is None:
+            vals = {}
+        self.update(vals)
+        self.status = int(self.get('status', 200))
 
 
 class HttpMock(object):
-    """Mock of httplib2.Http"""
+    """Mock of HTTP object."""
 
-    def __init__(self, headers=None):
+    def __init__(self, headers=None, data=None):
         """HttpMock constructor.
 
         Args:
@@ -30,7 +36,7 @@ class HttpMock(object):
         """
         if headers is None:
             headers = {'status': '200'}
-        self.data = None
+        self.data = data
         self.response_headers = headers
         self.headers = None
         self.uri = None
@@ -48,15 +54,15 @@ class HttpMock(object):
         self.method = method
         self.body = body
         self.headers = headers
-        return httplib2.Response(self.response_headers), self.data
+        return ResponseMock(self.response_headers), self.data
 
 
 class HttpMockSequence(object):
-    """Mock of httplib2.Http
+    """Mock of HTTP object with multiple return values.
 
     Mocks a sequence of calls to request returning different responses for each
     call. Create an instance initialized with the desired response headers
-    and content and then use as if an httplib2.Http instance::
+    and content and then use as if an HttpMock instance::
 
         http = HttpMockSequence([
             ({'status': '401'}, b''),
@@ -99,7 +105,7 @@ class HttpMockSequence(object):
         elif content == 'echo_request_body':
             content = (body
                        if body_stream_content is None else body_stream_content)
-        return httplib2.Response(resp), content
+        return ResponseMock(resp), content
 
 
 class CacheMock(object):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -908,14 +908,14 @@ class BasicCredentialsTests(unittest2.TestCase):
             self.assertEqual(token_response, self.credentials.token_response)
 
     def test_recursive_authorize(self):
-        # Tests that OAuth2Credentials doesn't introduce new method constraints.
-        # Formerly, OAuth2Credentials.authorize monkeypatched the request method
-        # of the passed in HTTP object with a wrapper annotated with
-        # @util.positional(1). Since the original method has no such annotation,
-        # that meant that the wrapper was violating the contract of the original
-        # method by adding a new requirement to it. And in fact the wrapper
-        # itself doesn't even respect that requirement. So before the removal of
-        # the annotation, this test would fail.
+        # Tests that OAuth2Credentials doesn't introduce new method
+        # constraints. Formerly, OAuth2Credentials.authorize monkeypatched the
+        # request method of the passed in HTTP object with a wrapper annotated
+        # with @util.positional(1). Since the original method has no such
+        # annotation, that meant that the wrapper was violating the contract of
+        # the original method by adding a new requirement to it. And in fact
+        # the wrapper itself doesn't even respect that requirement. So before
+        # the removal of the annotation, this test would fail.
         token_response = {'access_token': '1/3w', 'expires_in': 3600}
         encoded_response = json.dumps(token_response).encode('utf-8')
         http = http_mock.HttpMock(data=encoded_response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -908,7 +908,7 @@ class BasicCredentialsTests(unittest2.TestCase):
             self.assertEqual(token_response, self.credentials.token_response)
 
     def test_recursive_authorize(self):
-        # Tests that OAuth2Credentials doesn't intro. new method constraints.
+        # Tests that OAuth2Credentials doesn't introduce new method constraints.
         # Formerly, OAuth2Credentials.authorize monkeypatched the request method
         # of the passed in HTTP object with a wrapper annotated with
         # @util.positional(1). Since the original method has no such annotation,

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -22,7 +22,6 @@ import json
 import os
 import tempfile
 
-import httplib2
 import mock
 import rsa
 from six import BytesIO
@@ -488,9 +487,10 @@ class JWTAccessCredentialsTests(unittest2.TestCase):
             self.assertEqual(payload['exp'], T1_EXPIRY)
             self.assertEqual(uri, self.url)
             self.assertEqual(bearer, b'Bearer')
-            return (httplib2.Response({'status': '200'}), b'')
+            response = mock.Mock(status=200)
+            return response, b''
 
-        h = httplib2.Http()
+        h = mock.Mock()
         h.request = mock_request
         self.jwt.authorize(h)
         h.request(self.url)
@@ -523,9 +523,10 @@ class JWTAccessCredentialsTests(unittest2.TestCase):
             self.assertEqual(payload['exp'], T1_EXPIRY)
             self.assertEqual(uri, self.url)
             self.assertEqual(bearer, b'Bearer')
-            return httplib2.Response({'status': '200'}), b''
+            response = mock.Mock(status=200)
+            return response, b''
 
-        h = httplib2.Http()
+        h = mock.Mock()
         h.request = mock_request
         jwt.authorize(h)
         h.request(self.url)


### PR DESCRIPTION
The only remaining unit test module utilizing `httplib2` is `test_transport` since it utilizes `httplib2` directly at the moment.

Towards #128

```
$ git grep -i -l httplib2 -- tests/
tests/test_transport.py
```
