### PR TITLE
Remove all uses of MagicMock

### DIFF
--- a/tests/contrib/django_util/test_decorators.py
+++ b/tests/contrib/django_util/test_decorators.py
@@ -63,7 +63,7 @@ class OAuth2EnabledDecoratorTest(TestWithDjangoEnvironment):
     @mock.patch('oauth2client.client.OAuth2Credentials')
     def test_has_credentials_in_storage(self, OAuth2Credentials):
         request = self.factory.get('/test')
-        request.session = mock.MagicMock()
+        request.session = mock.Mock()
 
         credentials_mock = mock.Mock(
             scopes=set(django.conf.settings.GOOGLE_OAUTH2_SCOPES))
@@ -88,7 +88,7 @@ class OAuth2EnabledDecoratorTest(TestWithDjangoEnvironment):
     @mock.patch('oauth2client.contrib.dictionary_storage.DictionaryStorage')
     def test_specified_scopes(self, dictionary_storage_mock):
         request = self.factory.get('/test')
-        request.session = mock.MagicMock()
+        request.session = mock.Mock()
 
         credentials_mock = mock.Mock(
             scopes=set(django.conf.settings.GOOGLE_OAUTH2_SCOPES))
@@ -141,13 +141,13 @@ class OAuth2RequiredDecoratorTest(TestWithDjangoEnvironment):
     @mock.patch('oauth2client.contrib.django_util.UserOAuth2', autospec=True)
     def test_has_credentials_in_storage(self, UserOAuth2):
         request = self.factory.get('/test')
-        request.session = mock.MagicMock()
+        request.session = mock.Mock()
 
         @decorators.oauth_required
         def test_view(request):
             return http.HttpResponse("test")
 
-        my_user_oauth = mock.MagicMock()
+        my_user_oauth = mock.Mock()
 
         UserOAuth2.return_value = my_user_oauth
         my_user_oauth.has_credentials.return_value = True
@@ -161,7 +161,7 @@ class OAuth2RequiredDecoratorTest(TestWithDjangoEnvironment):
             self, OAuth2Credentials):
         request = self.factory.get('/test')
 
-        request.session = mock.MagicMock()
+        request.session = mock.Mock()
         credentials_mock = mock.Mock(
             scopes=set(django.conf.settings.GOOGLE_OAUTH2_SCOPES))
         credentials_mock.has_scopes.return_value = False
@@ -179,7 +179,7 @@ class OAuth2RequiredDecoratorTest(TestWithDjangoEnvironment):
     @mock.patch('oauth2client.client.OAuth2Credentials')
     def test_specified_scopes(self, OAuth2Credentials):
         request = self.factory.get('/test')
-        request.session = mock.MagicMock()
+        request.session = mock.Mock()
 
         credentials_mock = mock.Mock(
             scopes=set(django.conf.settings.GOOGLE_OAUTH2_SCOPES))

--- a/tests/contrib/test_devshell.py
+++ b/tests/contrib/test_devshell.py
@@ -75,25 +75,25 @@ class Test_SendRecv(unittest2.TestCase):
 
     def test_port_zero(self):
         with mock.patch('oauth2client.contrib.devshell.os') as os_mod:
-            os_mod.getenv = mock.MagicMock(name='getenv', return_value=0)
+            os_mod.getenv = mock.Mock(name='getenv', return_value=0)
             with self.assertRaises(devshell.NoDevshellServer):
                 devshell._SendRecv()
             os_mod.getenv.assert_called_once_with(devshell.DEVSHELL_ENV, 0)
 
     def test_no_newline_in_received_header(self):
         non_zero_port = 1
-        sock = mock.MagicMock()
+        sock = mock.Mock()
 
         header_without_newline = ''
-        sock.recv(6).decode = mock.MagicMock(
+        sock.recv(6).decode = mock.Mock(
             name='decode', return_value=header_without_newline)
 
         with mock.patch('oauth2client.contrib.devshell.os') as os_mod:
-            os_mod.getenv = mock.MagicMock(name='getenv',
-                                           return_value=non_zero_port)
+            os_mod.getenv = mock.Mock(name='getenv',
+                                      return_value=non_zero_port)
             with mock.patch('oauth2client.contrib.devshell.socket') as socket:
-                socket.socket = mock.MagicMock(name='socket',
-                                               return_value=sock)
+                socket.socket = mock.Mock(name='socket',
+                                          return_value=sock)
                 with self.assertRaises(devshell.CommunicationError):
                     devshell._SendRecv()
                 os_mod.getenv.assert_called_once_with(devshell.DEVSHELL_ENV, 0)

--- a/tests/contrib/test_keyring_storage.py
+++ b/tests/contrib/test_keyring_storage.py
@@ -58,15 +58,15 @@ class KeyringStorageTests(unittest2.TestCase):
         service_name = 'my_unit_test'
         user_name = 'me'
         mock_content = (object(), 'mock_content')
-        mock_return_creds = mock.MagicMock()
-        mock_return_creds.set_store = set_store = mock.MagicMock(
+        mock_return_creds = mock.Mock()
+        mock_return_creds.set_store = set_store = mock.Mock(
             name='set_store')
         with mock.patch.object(keyring, 'get_password',
                                return_value=mock_content,
                                autospec=True) as get_password:
             class_name = 'oauth2client.client.Credentials'
             with mock.patch(class_name) as MockCreds:
-                MockCreds.new_from_json = new_from_json = mock.MagicMock(
+                MockCreds.new_from_json = new_from_json = mock.Mock(
                     name='new_from_json', return_value=mock_return_creds)
                 store = keyring_storage.Storage(service_name, user_name)
                 credentials = store.locked_get()
@@ -82,9 +82,9 @@ class KeyringStorageTests(unittest2.TestCase):
         with mock.patch.object(keyring, 'set_password',
                                return_value=None,
                                autospec=True) as set_password:
-            credentials = mock.MagicMock()
+            credentials = mock.Mock()
             to_json_ret = object()
-            credentials.to_json = to_json = mock.MagicMock(
+            credentials.to_json = to_json = mock.Mock(
                 name='to_json', return_value=to_json_ret)
             store.locked_put(credentials)
             to_json.assert_called_once_with()

--- a/tests/contrib/test_xsrfutil.py
+++ b/tests/contrib/test_xsrfutil.py
@@ -49,10 +49,10 @@ class Test_generate_token(unittest2.TestCase):
 
     def test_it(self):
         digest = b'foobar'
-        digester = mock.MagicMock()
-        digester.digest = mock.MagicMock(name='digest', return_value=digest)
+        digester = mock.Mock()
+        digester.digest = mock.Mock(name='digest', return_value=digest)
         with mock.patch('oauth2client.contrib.xsrfutil.hmac') as hmac:
-            hmac.new = mock.MagicMock(name='new', return_value=digester)
+            hmac.new = mock.Mock(name='new', return_value=digester)
             token = xsrfutil.generate_token(TEST_KEY,
                                             TEST_USER_ID_1,
                                             action_id=TEST_ACTION_ID_1,
@@ -78,13 +78,13 @@ class Test_generate_token(unittest2.TestCase):
     def test_with_system_time(self):
         digest = b'foobar'
         curr_time = 1440449755.74
-        digester = mock.MagicMock()
-        digester.digest = mock.MagicMock(name='digest', return_value=digest)
+        digester = mock.Mock()
+        digester.digest = mock.Mock(name='digest', return_value=digest)
         with mock.patch('oauth2client.contrib.xsrfutil.hmac') as hmac:
-            hmac.new = mock.MagicMock(name='new', return_value=digester)
+            hmac.new = mock.Mock(name='new', return_value=digester)
 
             with mock.patch('oauth2client.contrib.xsrfutil.time') as time:
-                time.time = mock.MagicMock(name='time', return_value=curr_time)
+                time.time = mock.Mock(name='time', return_value=curr_time)
                 # when= is omitted
                 token = xsrfutil.generate_token(TEST_KEY,
                                                 TEST_USER_ID_1,
@@ -142,7 +142,7 @@ class Test_validate_token(unittest2.TestCase):
         key = user_id = None
         token = base64.b64encode(_helpers._to_bytes(str(token_time)))
         with mock.patch('oauth2client.contrib.xsrfutil.time') as time:
-            time.time = mock.MagicMock(name='time', return_value=curr_time)
+            time.time = mock.Mock(name='time', return_value=curr_time)
             self.assertFalse(xsrfutil.validate_token(key, token, user_id))
             time.time.assert_called_once_with()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -362,18 +362,18 @@ class GoogleCredentialsTests(unittest2.TestCase):
 
     def _environment_check_gce_helper(self, status_ok=True, socket_error=False,
                                       server_software=''):
-        response = mock.MagicMock()
+        response = mock.Mock()
         if status_ok:
             response.status = http_client.OK
-            response.getheader = mock.MagicMock(
+            response.getheader = mock.Mock(
                 name='getheader',
                 return_value=client._DESIRED_METADATA_FLAVOR)
         else:
             response.status = http_client.NOT_FOUND
 
-        connection = mock.MagicMock()
-        connection.getresponse = mock.MagicMock(name='getresponse',
-                                                return_value=response)
+        connection = mock.Mock()
+        connection.getresponse = mock.Mock(name='getresponse',
+                                           return_value=response)
         if socket_error:
             connection.getresponse.side_effect = socket.error()
 
@@ -381,7 +381,7 @@ class GoogleCredentialsTests(unittest2.TestCase):
             os_module.environ = {client._SERVER_SOFTWARE: server_software}
             with mock.patch('oauth2client.client.six') as six_module:
                 http_client_module = six_module.moves.http_client
-                http_client_module.HTTPConnection = mock.MagicMock(
+                http_client_module.HTTPConnection = mock.Mock(
                     name='HTTPConnection', return_value=connection)
 
                 if server_software == '':
@@ -1265,7 +1265,7 @@ class BasicCredentialsTests(unittest2.TestCase):
         response = http_mock.ResponseMock({'status': http_client.BAD_GATEWAY})
         error_msg = 'Where are we going wearer?'
         content = json.dumps({'error': error_msg})
-        store = mock.MagicMock()
+        store = mock.Mock()
         self._do_refresh_request_test_helper(response, content, error_msg,
                                              store=store)
 
@@ -1323,7 +1323,7 @@ class BasicCredentialsTests(unittest2.TestCase):
 
     def test__do_revoke_success_with_store(self):
         response = http_mock.ResponseMock()
-        store = mock.MagicMock()
+        store = mock.Mock()
         self._do_revoke_test_helper(response, b'', None, store=store)
 
     def test__do_revoke_non_json_failure(self):
@@ -1349,7 +1349,7 @@ class BasicCredentialsTests(unittest2.TestCase):
         response = http_mock.ResponseMock({'status': http_client.BAD_GATEWAY})
         error_msg = 'Where are we going wearer?'
         content = json.dumps({'error': error_msg})
-        store = mock.MagicMock()
+        store = mock.Mock()
         self._do_revoke_test_helper(response, content, error_msg,
                                     store=store)
 

--- a/tests/test_crypt.py
+++ b/tests/test_crypt.py
@@ -80,11 +80,11 @@ class Test__verify_signature(unittest2.TestCase):
         message = object()
         signature = object()
 
-        verifier = mock.MagicMock()
-        verifier.verify = mock.MagicMock(name='verify', return_value=True)
+        verifier = mock.Mock()
+        verifier.verify = mock.Mock(name='verify', return_value=True)
         with mock.patch('oauth2client.crypt.Verifier') as Verifier:
-            Verifier.from_string = mock.MagicMock(name='from_string',
-                                                  return_value=verifier)
+            Verifier.from_string = mock.Mock(name='from_string',
+                                             return_value=verifier)
             result = crypt._verify_signature(message, signature, certs)
             self.assertEqual(result, None)
 
@@ -101,14 +101,14 @@ class Test__verify_signature(unittest2.TestCase):
         message = object()
         signature = object()
 
-        verifier = mock.MagicMock()
+        verifier = mock.Mock()
         # Use side_effect to force all 3 cert values to be used by failing
         # to verify on the first two.
-        verifier.verify = mock.MagicMock(name='verify',
-                                         side_effect=[False, False, True])
+        verifier.verify = mock.Mock(name='verify',
+                                    side_effect=[False, False, True])
         with mock.patch('oauth2client.crypt.Verifier') as Verifier:
-            Verifier.from_string = mock.MagicMock(name='from_string',
-                                                  return_value=verifier)
+            Verifier.from_string = mock.Mock(name='from_string',
+                                             return_value=verifier)
             result = crypt._verify_signature(message, signature, certs)
             self.assertEqual(result, None)
 
@@ -130,11 +130,11 @@ class Test__verify_signature(unittest2.TestCase):
         message = object()
         signature = object()
 
-        verifier = mock.MagicMock()
-        verifier.verify = mock.MagicMock(name='verify', return_value=False)
+        verifier = mock.Mock()
+        verifier.verify = mock.Mock(name='verify', return_value=False)
         with mock.patch('oauth2client.crypt.Verifier') as Verifier:
-            Verifier.from_string = mock.MagicMock(name='from_string',
-                                                  return_value=verifier)
+            Verifier.from_string = mock.Mock(name='from_string',
+                                             return_value=verifier)
             with self.assertRaises(crypt.AppIdentityError):
                 crypt._verify_signature(message, signature, certs)
 
@@ -204,8 +204,8 @@ class Test__verify_time_range(unittest2.TestCase):
             'exp': current_time + crypt.MAX_TOKEN_LIFETIME_SECS + 1,
         }
         with mock.patch('oauth2client.crypt.time') as time:
-            time.time = mock.MagicMock(name='time',
-                                       return_value=current_time)
+            time.time = mock.Mock(name='time',
+                                  return_value=current_time)
 
             exception_caught = self._exception_helper(payload_dict)
             self.assertNotEqual(exception_caught, None)
@@ -219,8 +219,8 @@ class Test__verify_time_range(unittest2.TestCase):
             'exp': current_time + crypt.MAX_TOKEN_LIFETIME_SECS - 1,
         }
         with mock.patch('oauth2client.crypt.time') as time:
-            time.time = mock.MagicMock(name='time',
-                                       return_value=current_time)
+            time.time = mock.Mock(name='time',
+                                  return_value=current_time)
 
             exception_caught = self._exception_helper(payload_dict)
             self.assertNotEqual(exception_caught, None)
@@ -234,8 +234,8 @@ class Test__verify_time_range(unittest2.TestCase):
             'exp': current_time - crypt.CLOCK_SKEW_SECS - 1,
         }
         with mock.patch('oauth2client.crypt.time') as time:
-            time.time = mock.MagicMock(name='time',
-                                       return_value=current_time)
+            time.time = mock.Mock(name='time',
+                                  return_value=current_time)
 
             exception_caught = self._exception_helper(payload_dict)
             self.assertNotEqual(exception_caught, None)
@@ -249,8 +249,8 @@ class Test__verify_time_range(unittest2.TestCase):
             'exp': current_time + crypt.MAX_TOKEN_LIFETIME_SECS - 1,
         }
         with mock.patch('oauth2client.crypt.time') as time:
-            time.time = mock.MagicMock(name='time',
-                                       return_value=current_time)
+            time.time = mock.Mock(name='time',
+                                  return_value=current_time)
 
             exception_caught = self._exception_helper(payload_dict)
             self.assertEqual(exception_caught, None)
@@ -288,10 +288,10 @@ class Test_verify_signed_jwt_with_certs(unittest2.TestCase):
     @mock.patch('oauth2client.crypt._verify_time_range')
     @mock.patch('oauth2client.crypt._verify_signature')
     def test_success(self, verify_sig, verify_time, check_aud):
-        certs = mock.MagicMock()
+        certs = mock.Mock()
         cert_values = object()
-        certs.values = mock.MagicMock(name='values',
-                                      return_value=cert_values)
+        certs.values = mock.Mock(name='values',
+                                 return_value=cert_values)
         audience = object()
 
         header = b'header'

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -275,10 +275,10 @@ class ServiceAccountCredentialsTests(unittest2.TestCase):
         utcnow.return_value = NOW
 
         # Create a custom credentials with a mock signer.
-        signer = mock.MagicMock()
+        signer = mock.Mock()
         signed_value = b'signed-content'
-        signer.sign = mock.MagicMock(name='sign',
-                                     return_value=signed_value)
+        signer.sign = mock.Mock(name='sign',
+                                return_value=signed_value)
         credentials = service_account.ServiceAccountCredentials(
             self.service_account_email,
             signer,


### PR DESCRIPTION
`MagicMock` is a version of `Mock` with extra features for tests that need to test usage of magic methods (i.e. `__nonzero__`, `__cmp__`, etc.).

None of the `oauth2client` tests actually need these extra features though.
