### PR TITLE
Drop Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     env: TOX_ENV=gae
   - python: 2.7
     env: TOX_ENV=py27
-  - python: 3.3
-    env: TOX_ENV=py33
   - python: 3.4
     env: TOX_ENV=py34
   - python: 3.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,10 +127,6 @@ Running Tests
     least version 2.6 of `pypy` installed. See the [docs][13] for
     more information.
 
--   **Note** that `django` related tests are turned off for Python 2.6
-    and 3.3. This is because `django` dropped support for
-    [2.6 in `django==1.7`][14] and for [3.3 in `django==1.9`][15].
-
 Running System Tests
 --------------------
 
@@ -202,7 +198,5 @@ we'll be able to accept your pull requests.
 [11]: #include-tests
 [12]: #make-the-pull-request
 [13]: https://oauth2client.readthedocs.io/en/latest/#using-pypy
-[14]: https://docs.djangoproject.com/en/1.7/faq/install/#what-python-version-can-i-use-with-django
-[15]: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django
 [GooglePythonStyle]: https://google.github.io/styleguide/pyguide.html
 [GitCommitRules]: http://chris.beams.io/posts/git-commit/#seven-rules

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ agreement.
 Supported Python Versions
 =========================
 
-We support Python 2.7 and 3.3+. More information [in the docs][2].
+We support Python 2.7 and 3.4+. More information [in the docs][2].
 
 [1]: https://github.com/google/oauth2client/blob/master/CONTRIBUTING.md
 [2]: https://oauth2client.readthedocs.io/#supported-python-versions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,18 +107,24 @@ contributor license agreement.
 Supported Python Versions
 -------------------------
 
-We support Python 2.7 and 3.3+. (Whatever this file says, the truth is
+We support Python 2.7 and 3.4+. (Whatever this file says, the truth is
 always represented by our `tox.ini`_).
 
 .. _tox.ini: https://github.com/google/oauth2client/blob/master/tox.ini
 
 We explicitly decided to support Python 3 beginning with version
-3.3. Reasons for this include:
+3.4. Reasons for this include:
 
 * Encouraging use of newest versions of Python 3
 * Following the lead of prominent `open-source projects`_
 * Unicode literal support which
   allows for a cleaner codebase that works in both Python 2 and Python 3
+* Prominent projects like `django`_ have `dropped support`_ for earlier
+  versions (3.3 support dropped in December 2015, and 2.6 support
+  `dropped`_ in September 2014)
 
 .. _open-source projects: http://docs.python-requests.org/en/latest/
 .. _Unicode literal support: https://www.python.org/dev/peps/pep-0414/
+.. _django: https://docs.djangoproject.com/
+.. _dropped support: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django
+.. _dropped: https://docs.djangoproject.com/en/1.7/faq/install/#what-python-version-can-i-use-with-django

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ import oauth2client
 if sys.version_info < (2, 7):
     print('oauth2client requires python2 version >= 2.7.', file=sys.stderr)
     sys.exit(1)
-if (3, 1) <= sys.version_info < (3, 3):
-    print('oauth2client requires python3 version >= 3.3.', file=sys.stderr)
+if (3, 1) <= sys.version_info < (3, 4):
+    print('oauth2client requires python3 version >= 3.4.', file=sys.stderr)
     sys.exit(1)
 
 install_requires = [
@@ -41,27 +41,27 @@ install_requires = [
     'six>=1.6.1',
 ]
 
-long_desc = """The oauth2client is a client library for OAuth 2.0."""
+long_desc = 'oauth2client is a client library for OAuth 2.0.'
 
 version = oauth2client.__version__
 
 setup(
-    name="oauth2client",
+    name='oauth2client',
     version=version,
-    description="OAuth 2.0 client library",
+    description='OAuth 2.0 client library',
     long_description=long_desc,
-    author="Google Inc.",
-    url="http://github.com/google/oauth2client/",
+    author='Google Inc.',
+    url='http://github.com/google/oauth2client/',
     install_requires=install_requires,
     packages=find_packages(),
-    license="Apache 2.0",
-    keywords="google oauth 2.0 http client",
+    license='Apache 2.0',
+    keywords='google oauth 2.0 http client',
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,gae,cover
+envlist = py27,py34,py35,pypy,gae,cover
 
 [testenv]
 basedeps = mock>=1.3.0
@@ -18,7 +18,7 @@ deps = {[testenv]basedeps}
 setenv =
     pypy: with_gmp=no
     DJANGO_SETTINGS_MODULE=tests.contrib.django_util.settings
-commands = 
+commands =
     py.test {posargs}
 
 [coverbase]
@@ -36,17 +36,6 @@ commands =
 deps = {[testenv]deps}
     coverage
     pytest-cov
-
-[testenv:py33]
-basepython =
-    python3.3
-commands =
-    py.test \
-      --ignore=oauth2client/contrib/django_util \
-      --ignore=tests/contrib/django_util \
-      {posargs}
-deps = {[testenv]basedeps}
-       keyring
 
 [testenv:cover]
 basepython = {[coverbase]basepython}


### PR DESCRIPTION
Also remove some trailing whitespace in `tox.ini` (my editor did this) and fixing up some double quote / single quote mixing in `setup.py`.

Fixes #603.
