### PR TITLE
Clean up usage of HTTP mocks in tests.

### DIFF
--- a/tests/http_mock.py
+++ b/tests/http_mock.py
@@ -46,6 +46,7 @@ class HttpMock(object):
         self.method = None
         self.body = None
         self.headers = None
+        self.requests = 0
 
     def request(self, uri,
                 method='GET',
@@ -57,6 +58,8 @@ class HttpMock(object):
         self.method = method
         self.body = body
         self.headers = headers
+        self.redirections = redirections
+        self.requests += 1
         return ResponseMock(self.response_headers), self.data
 
 
@@ -89,7 +92,6 @@ class HttpMockSequence(object):
             iterable: iterable, a sequence of pairs of (headers, body)
         """
         self._iterable = iterable
-        self.follow_redirects = True
         self.requests = []
 
     def request(self, uri,
@@ -99,7 +101,12 @@ class HttpMockSequence(object):
                 redirections=1,
                 connection_type=None):
         resp, content = self._iterable.pop(0)
-        self.requests.append({'uri': uri, 'body': body, 'headers': headers})
+        self.requests.append({
+            'method': method,
+            'uri': uri,
+            'body': body,
+            'headers': headers,
+        })
         # Read any underlying stream before sending the request.
         body_stream_content = (body.read()
                                if getattr(body, 'read', None) else None)


### PR DESCRIPTION
This is a follow-on to #602, and partially making good on a [comment](https://github.com/google/oauth2client/pull/586/files#r73388113) I made in #586.

I checked the types of `http` values sent to `transport.request` by adding:

``` python
from tests import http_mock
import types
if type(http) == http_mock.HttpMock:
    pass
elif type(http) == http_mock.HttpMockSequence:
    pass
elif (type(http) == types.MethodType and
      http.__self__.__class__ == http_mock.HttpMock):
    pass
elif (type(http) == types.MethodType and
      http.__self__.__class__ == http_mock.HttpMockSequence):
    pass
elif (type(http) == types.FunctionType and
      http.__name__ == 'new_request'):
    pass
else:
    raise MyErr(http)
```

I also did `git grep http_request` to find some other iffy usage. I'd also like to track down usage of `http.request` (or just `.request` on an object).

The method type and function type checks are to accommodate the hacky way an `http` object is monkey-patched, so I'd also like to fix those up as part of #128. 
