### PR TITLE
Drop unittest2 dependency

### DIFF
--- a/scripts/run_gce_system_tests.py
+++ b/scripts/run_gce_system_tests.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import json
+import unittest
 
 from six.moves import http_client
 from six.moves import urllib
-import unittest2
 
 import oauth2client
 from oauth2client import client
@@ -24,7 +24,7 @@ from oauth2client import transport
 from oauth2client.contrib import gce
 
 
-class TestComputeEngine(unittest2.TestCase):
+class TestComputeEngine(unittest.TestCase):
 
     def test_application_default(self):
         default_creds = client.GoogleCredentials.get_application_default()
@@ -53,4 +53,4 @@ class TestComputeEngine(unittest2.TestCase):
 
 
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/tests/contrib/appengine/test__appengine_ndb.py
+++ b/tests/contrib/appengine/test__appengine_ndb.py
@@ -14,11 +14,11 @@
 
 import json
 import os
+import unittest
 
 from google.appengine.ext import ndb
 from google.appengine.ext import testbed
 import mock
-import unittest2
 
 from oauth2client import client
 from oauth2client.contrib import appengine
@@ -36,7 +36,7 @@ class TestNDBModel(ndb.Model):
     creds = appengine.CredentialsNDBProperty()
 
 
-class TestFlowNDBProperty(unittest2.TestCase):
+class TestFlowNDBProperty(unittest.TestCase):
 
     def setUp(self):
         self.testbed = testbed.Testbed()
@@ -85,7 +85,7 @@ class TestFlowNDBProperty(unittest2.TestCase):
                                                  type(flow_val))
 
 
-class TestCredentialsNDBProperty(unittest2.TestCase):
+class TestCredentialsNDBProperty(unittest.TestCase):
 
     def setUp(self):
         self.testbed = testbed.Testbed()

--- a/tests/contrib/appengine/test_appengine.py
+++ b/tests/contrib/appengine/test_appengine.py
@@ -17,6 +17,7 @@ import json
 import os
 import tempfile
 import time
+import unittest
 
 from google.appengine.api import apiproxy_stub
 from google.appengine.api import apiproxy_stub_map
@@ -30,7 +31,6 @@ from google.appengine.ext import testbed
 import mock
 from six.moves import urllib
 from six.moves import urllib_parse
-import unittest2
 import webapp2
 from webtest import TestApp
 
@@ -81,7 +81,7 @@ class UserNotLoggedInMock(object):
         return None
 
 
-class TestAppAssertionCredentials(unittest2.TestCase):
+class TestAppAssertionCredentials(unittest.TestCase):
     account_name = "service_account_name@appspot.com"
     signature = "signature"
 
@@ -266,7 +266,7 @@ class TestFlowModel(db.Model):
     flow = appengine.FlowProperty()
 
 
-class FlowPropertyTest(unittest2.TestCase):
+class FlowPropertyTest(unittest.TestCase):
 
     def setUp(self):
         self.testbed = testbed.Testbed()
@@ -305,7 +305,7 @@ class TestCredentialsModel(db.Model):
     credentials = appengine.CredentialsProperty()
 
 
-class CredentialsPropertyTest(unittest2.TestCase):
+class CredentialsPropertyTest(unittest.TestCase):
 
     def setUp(self):
         self.testbed = testbed.Testbed()
@@ -359,7 +359,7 @@ class CredentialsPropertyTest(unittest2.TestCase):
             appengine.CredentialsProperty().validate(42)
 
 
-class StorageByKeyNameTest(unittest2.TestCase):
+class StorageByKeyNameTest(unittest.TestCase):
 
     def setUp(self):
         self.testbed = testbed.Testbed()
@@ -596,7 +596,7 @@ class MockRequestHandler(object):
     request = MockRequest()
 
 
-class DecoratorTests(unittest2.TestCase):
+class DecoratorTests(unittest.TestCase):
 
     def setUp(self):
         self.testbed = testbed.Testbed()
@@ -1051,7 +1051,7 @@ class DecoratorTests(unittest2.TestCase):
         new_http.assert_called_once_with()
 
 
-class DecoratorXsrfSecretTests(unittest2.TestCase):
+class DecoratorXsrfSecretTests(unittest.TestCase):
     """Test xsrf_secret_key."""
 
     def setUp(self):
@@ -1100,7 +1100,7 @@ class DecoratorXsrfSecretTests(unittest2.TestCase):
         self.assertEqual(site_key.secret, secret)
 
 
-class DecoratorXsrfProtectionTests(unittest2.TestCase):
+class DecoratorXsrfProtectionTests(unittest.TestCase):
     """Test _build_state_value and _parse_state_value."""
 
     def setUp(self):

--- a/tests/contrib/django_util/test_django_models.py
+++ b/tests/contrib/django_util/test_django_models.py
@@ -19,17 +19,16 @@ Unit tests for models and fields defined by the django_util helper.
 
 import base64
 import pickle
+import unittest
 
 from tests.contrib.django_util.models import CredentialsModel
-
-import unittest2
 
 from oauth2client import _helpers
 from oauth2client.client import Credentials
 from oauth2client.contrib.django_util.models import CredentialsField
 
 
-class TestCredentialsField(unittest2.TestCase):
+class TestCredentialsField(unittest.TestCase):
 
     def setUp(self):
         self.fake_model = CredentialsModel()

--- a/tests/contrib/django_util/test_django_storage.py
+++ b/tests/contrib/django_util/test_django_storage.py
@@ -16,10 +16,10 @@
 
 # Mock a Django environment
 import datetime
+import unittest
 
 from django.db import models
 import mock
-import unittest2
 
 from oauth2client import GOOGLE_TOKEN_URI
 from oauth2client.client import OAuth2Credentials
@@ -28,7 +28,7 @@ from oauth2client.contrib.django_util.storage import (
     DjangoORMStorage as Storage)
 
 
-class TestStorage(unittest2.TestCase):
+class TestStorage(unittest.TestCase):
     def setUp(self):
         access_token = 'foo'
         client_id = 'some_client_id'

--- a/tests/contrib/django_util/test_django_util.py
+++ b/tests/contrib/django_util/test_django_util.py
@@ -15,6 +15,7 @@
 """Tests the initialization logic of django_util."""
 
 import copy
+import unittest
 
 import django.conf
 from django.conf.urls import include, url
@@ -23,7 +24,6 @@ from django.core import exceptions
 import mock
 from six.moves import reload_module
 from tests.contrib.django_util import TestWithDjangoEnvironment
-import unittest2
 
 from oauth2client.contrib import django_util
 import oauth2client.contrib.django_util
@@ -36,7 +36,7 @@ urlpatterns = [
 ]
 
 
-class OAuth2SetupTest(unittest2.TestCase):
+class OAuth2SetupTest(unittest.TestCase):
 
     def setUp(self):
         self.save_settings = copy.deepcopy(django.conf.settings)

--- a/tests/contrib/test_devshell.py
+++ b/tests/contrib/test_devshell.py
@@ -19,9 +19,9 @@ import json
 import os
 import socket
 import threading
+import unittest
 
 import mock
-import unittest2
 
 from oauth2client import _helpers
 from oauth2client import client
@@ -38,7 +38,7 @@ DEFAULT_CREDENTIAL_JSON = json.dumps([
 ])
 
 
-class TestCredentialInfoResponse(unittest2.TestCase):
+class TestCredentialInfoResponse(unittest.TestCase):
 
     def test_constructor_with_non_list(self):
         json_non_list = '{}'
@@ -71,7 +71,7 @@ class TestCredentialInfoResponse(unittest2.TestCase):
         self.assertEqual(info_response.expires_in, expires_in)
 
 
-class Test_SendRecv(unittest2.TestCase):
+class Test_SendRecv(unittest.TestCase):
 
     def test_port_zero(self):
         with mock.patch('oauth2client.contrib.devshell.os') as os_mod:
@@ -168,7 +168,7 @@ class _AuthReferenceServer(threading.Thread):
             s.close()
 
 
-class DevshellCredentialsTests(unittest2.TestCase):
+class DevshellCredentialsTests(unittest.TestCase):
 
     def test_signals_no_server(self):
         with self.assertRaises(devshell.NoDevshellServer):

--- a/tests/contrib/test_dictionary_storage.py
+++ b/tests/contrib/test_dictionary_storage.py
@@ -14,7 +14,7 @@
 
 """Unit tests for oauth2client.contrib.dictionary_storage"""
 
-import unittest2
+import unittest
 
 import oauth2client
 from oauth2client import client
@@ -37,7 +37,7 @@ def _generate_credentials(scopes=None):
         scopes=scopes)
 
 
-class DictionaryStorageTests(unittest2.TestCase):
+class DictionaryStorageTests(unittest.TestCase):
 
     def test_constructor_defaults(self):
         dictionary = {}

--- a/tests/contrib/test_flask_util.py
+++ b/tests/contrib/test_flask_util.py
@@ -17,12 +17,12 @@
 import datetime
 import json
 import logging
+import unittest
 
 import flask
 import mock
 import six.moves.http_client as httplib
 import six.moves.urllib.parse as urlparse
-import unittest2
 
 import oauth2client
 from oauth2client import client
@@ -44,7 +44,7 @@ DEFAULT_RESP = """\
 """
 
 
-class FlaskOAuth2Tests(unittest2.TestCase):
+class FlaskOAuth2Tests(unittest.TestCase):
 
     def setUp(self):
         self.app = flask.Flask(__name__)

--- a/tests/contrib/test_gce.py
+++ b/tests/contrib/test_gce.py
@@ -16,10 +16,10 @@
 
 import datetime
 import json
+import unittest
 
 import mock
 from six.moves import http_client
-import unittest2
 
 from oauth2client import client
 from oauth2client.contrib import _metadata
@@ -35,7 +35,7 @@ SERVICE_ACCOUNT_INFO = {
 METADATA_PATH = 'instance/service-accounts/a@example.com/token'
 
 
-class AppAssertionCredentialsTests(unittest2.TestCase):
+class AppAssertionCredentialsTests(unittest.TestCase):
 
     def test_constructor(self):
         credentials = gce.AppAssertionCredentials()

--- a/tests/contrib/test_keyring_storage.py
+++ b/tests/contrib/test_keyring_storage.py
@@ -16,10 +16,10 @@
 
 import datetime
 import threading
+import unittest
 
 import keyring
 import mock
-import unittest2
 
 import oauth2client
 from oauth2client import client
@@ -29,7 +29,7 @@ from oauth2client.contrib import keyring_storage
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
 
-class KeyringStorageTests(unittest2.TestCase):
+class KeyringStorageTests(unittest.TestCase):
 
     def test_constructor(self):
         service_name = 'my_unit_test'

--- a/tests/contrib/test_metadata.py
+++ b/tests/contrib/test_metadata.py
@@ -14,10 +14,10 @@
 
 import datetime
 import json
+import unittest
 
 import mock
 from six.moves import http_client
-import unittest2
 
 from oauth2client.contrib import _metadata
 from .. import http_mock
@@ -37,7 +37,7 @@ def request_mock(status, content_type, content):
     return http
 
 
-class TestMetadata(unittest2.TestCase):
+class TestMetadata(unittest.TestCase):
 
     def test_get_success_json(self):
         http = request_mock(

--- a/tests/contrib/test_multiprocess_file_storage.py
+++ b/tests/contrib/test_multiprocess_file_storage.py
@@ -20,11 +20,11 @@ import json
 import multiprocessing
 import os
 import tempfile
+import unittest
 
 import fasteners
 import mock
 from six import StringIO
-import unittest2
 
 from oauth2client import client
 from oauth2client.contrib import multiprocess_file_storage
@@ -75,7 +75,7 @@ def _generate_token_response_http(new_token='new_token'):
     return http
 
 
-class MultiprocessStorageBehaviorTests(unittest2.TestCase):
+class MultiprocessStorageBehaviorTests(unittest.TestCase):
 
     def setUp(self):
         filehandle, self.filename = tempfile.mkstemp(
@@ -200,7 +200,7 @@ class MultiprocessStorageBehaviorTests(unittest2.TestCase):
         self.assertIsNotNone(store.get())
 
 
-class MultiprocessStorageUnitTests(unittest2.TestCase):
+class MultiprocessStorageUnitTests(unittest.TestCase):
 
     def setUp(self):
         filehandle, self.filename = tempfile.mkstemp(
@@ -310,4 +310,4 @@ class MultiprocessStorageUnitTests(unittest2.TestCase):
 
 
 if __name__ == '__main__':  # pragma: NO COVER
-    unittest2.main()
+    unittest.main()

--- a/tests/contrib/test_sqlalchemy.py
+++ b/tests/contrib/test_sqlalchemy.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import datetime
+import unittest
 
 import sqlalchemy
 import sqlalchemy.ext.declarative
 import sqlalchemy.orm
-import unittest2
 
 import oauth2client
 import oauth2client.client
@@ -36,7 +36,7 @@ class DummyModel(Base):
         oauth2client.contrib.sqlalchemy.CredentialsType)
 
 
-class TestSQLAlchemyStorage(unittest2.TestCase):
+class TestSQLAlchemyStorage(unittest.TestCase):
     def setUp(self):
         engine = sqlalchemy.create_engine('sqlite://')
         Base.metadata.create_all(engine)

--- a/tests/contrib/test_xsrfutil.py
+++ b/tests/contrib/test_xsrfutil.py
@@ -15,9 +15,9 @@
 """Tests for oauth2client.contrib.xsrfutil."""
 
 import base64
+import unittest
 
 import mock
-import unittest2
 
 from oauth2client import _helpers
 from oauth2client.contrib import xsrfutil
@@ -37,7 +37,7 @@ TEST_EXTRA_INFO_2 = b'more_extra_info'
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
 
-class Test_generate_token(unittest2.TestCase):
+class Test_generate_token(unittest.TestCase):
 
     def test_bad_positional(self):
         # Need 2 positional arguments.
@@ -111,7 +111,7 @@ class Test_generate_token(unittest2.TestCase):
                 self.assertEqual(token, expected_token)
 
 
-class Test_validate_token(unittest2.TestCase):
+class Test_validate_token(unittest.TestCase):
 
     def test_bad_positional(self):
         # Need 3 positional arguments.
@@ -218,7 +218,7 @@ class Test_validate_token(unittest2.TestCase):
                                             when=token_time)
 
 
-class XsrfUtilTests(unittest2.TestCase):
+class XsrfUtilTests(unittest.TestCase):
     """Test xsrfutil functions."""
 
     def testGenerateAndValidateToken(self):

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -14,8 +14,9 @@
 
 """Unit tests for oauth2client._helpers."""
 
+import unittest
+
 import mock
-import unittest2
 
 from oauth2client import _helpers
 
@@ -23,7 +24,7 @@ from oauth2client import _helpers
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
 
-class PositionalTests(unittest2.TestCase):
+class PositionalTests(unittest.TestCase):
 
     def test_usage(self):
         _helpers.positional_parameters_enforcement = (
@@ -83,7 +84,7 @@ class PositionalTests(unittest2.TestCase):
         self.assertFalse(mock_logger.warning.called)
 
 
-class ScopeToStringTests(unittest2.TestCase):
+class ScopeToStringTests(unittest.TestCase):
 
     def test_iterables(self):
         cases = [
@@ -103,7 +104,7 @@ class ScopeToStringTests(unittest2.TestCase):
             self.assertEqual(expected, _helpers.scopes_to_string(case))
 
 
-class StringToScopeTests(unittest2.TestCase):
+class StringToScopeTests(unittest.TestCase):
 
     def test_conversion(self):
         cases = [
@@ -117,7 +118,7 @@ class StringToScopeTests(unittest2.TestCase):
             self.assertEqual(expected, _helpers.string_to_scopes(case))
 
 
-class AddQueryParameterTests(unittest2.TestCase):
+class AddQueryParameterTests(unittest.TestCase):
 
     def test__add_query_parameter(self):
         self.assertEqual(
@@ -138,7 +139,7 @@ class AddQueryParameterTests(unittest2.TestCase):
             '/action?a=+%3D')
 
 
-class Test__parse_pem_key(unittest2.TestCase):
+class Test__parse_pem_key(unittest.TestCase):
 
     def test_valid_input(self):
         test_string = b'1234-----BEGIN FOO BAR BAZ'
@@ -151,7 +152,7 @@ class Test__parse_pem_key(unittest2.TestCase):
         self.assertEqual(result, None)
 
 
-class Test__json_encode(unittest2.TestCase):
+class Test__json_encode(unittest.TestCase):
 
     def test_dictionary_input(self):
         # Use only a single key since dictionary hash order
@@ -166,7 +167,7 @@ class Test__json_encode(unittest2.TestCase):
         self.assertEqual(result, '[42,1337]')
 
 
-class Test__to_bytes(unittest2.TestCase):
+class Test__to_bytes(unittest.TestCase):
 
     def test_with_bytes(self):
         value = b'bytes-val'
@@ -183,7 +184,7 @@ class Test__to_bytes(unittest2.TestCase):
             _helpers._to_bytes(value)
 
 
-class Test__from_bytes(unittest2.TestCase):
+class Test__from_bytes(unittest.TestCase):
 
     def test_with_unicode(self):
         value = u'bytes-val'
@@ -200,7 +201,7 @@ class Test__from_bytes(unittest2.TestCase):
             _helpers._from_bytes(value)
 
 
-class Test__urlsafe_b64encode(unittest2.TestCase):
+class Test__urlsafe_b64encode(unittest.TestCase):
 
     DEADBEEF_ENCODED = b'ZGVhZGJlZWY'
 
@@ -215,7 +216,7 @@ class Test__urlsafe_b64encode(unittest2.TestCase):
         self.assertEqual(result, self.DEADBEEF_ENCODED)
 
 
-class Test__urlsafe_b64decode(unittest2.TestCase):
+class Test__urlsafe_b64decode(unittest.TestCase):
 
     def test_valid_input_bytes(self):
         test_string = b'ZGVhZGJlZWY'

--- a/tests/test__pure_python_crypt.py
+++ b/tests/test__pure_python_crypt.py
@@ -15,19 +15,19 @@
 """Unit tests for oauth2client._pure_python_crypt."""
 
 import os
+import unittest
 
 import mock
 from pyasn1_modules import pem
 import rsa
 import six
-import unittest2
 
 from oauth2client import _helpers
 from oauth2client import _pure_python_crypt
 from oauth2client import crypt
 
 
-class TestRsaVerifier(unittest2.TestCase):
+class TestRsaVerifier(unittest.TestCase):
 
     PUBLIC_KEY_FILENAME = os.path.join(os.path.dirname(__file__),
                                        'data', 'privatekey.pub')
@@ -112,7 +112,7 @@ class TestRsaVerifier(unittest2.TestCase):
             load_pem.assert_called_once_with(cert_bytes, 'CERTIFICATE')
 
 
-class TestRsaSigner(unittest2.TestCase):
+class TestRsaSigner(unittest.TestCase):
 
     PKCS1_KEY_FILENAME = os.path.join(os.path.dirname(__file__),
                                       'data', 'privatekey.pem')

--- a/tests/test__pycrypto_crypt.py
+++ b/tests/test__pycrypto_crypt.py
@@ -14,13 +14,12 @@
 """Unit tests for oauth2client._pycrypto_crypt."""
 
 import os
-
-import unittest2
+import unittest
 
 from oauth2client import crypt
 
 
-class TestPyCryptoVerifier(unittest2.TestCase):
+class TestPyCryptoVerifier(unittest.TestCase):
 
     PUBLIC_CERT_FILENAME = os.path.join(os.path.dirname(__file__),
                                         'data', 'public_cert.pem')
@@ -65,7 +64,7 @@ class TestPyCryptoVerifier(unittest2.TestCase):
         self.assertIsInstance(verifier, crypt.PyCryptoVerifier)
 
 
-class TestPyCryptoSigner(unittest2.TestCase):
+class TestPyCryptoSigner(unittest.TestCase):
 
     def test_from_string_bad_key(self):
         key_bytes = 'definitely-not-pem-format'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,12 +23,12 @@ import os
 import socket
 import sys
 import tempfile
+import unittest
 
 import mock
 import six
 from six.moves import http_client
 from six.moves import urllib
-import unittest2
 
 import oauth2client
 from oauth2client import _helpers
@@ -70,7 +70,7 @@ def load_and_cache(existing_file, fakename, cache_mock):
     cache_mock.cache[fakename] = {client_type: client_info}
 
 
-class CredentialsTests(unittest2.TestCase):
+class CredentialsTests(unittest.TestCase):
 
     def test_to_from_json(self):
         credentials = client.Credentials()
@@ -214,7 +214,7 @@ class CredentialsTests(unittest2.TestCase):
         self.assertEqual(credentials.__dict__, {})
 
 
-class TestStorage(unittest2.TestCase):
+class TestStorage(unittest.TestCase):
 
     def test_locked_get_abstract(self):
         storage = client.Storage()
@@ -249,7 +249,7 @@ def mock_module_import(module):
             del sys.modules[entry]
 
 
-class GoogleCredentialsTests(unittest2.TestCase):
+class GoogleCredentialsTests(unittest.TestCase):
 
     def setUp(self):
         self.os_name = os.name
@@ -864,7 +864,7 @@ def _token_revoke_test_helper(testcase, status, revoke_raise,
     testcase.credentials.set_store(current_store)
 
 
-class BasicCredentialsTests(unittest2.TestCase):
+class BasicCredentialsTests(unittest.TestCase):
 
     def setUp(self):
         access_token = 'foo'
@@ -1477,7 +1477,7 @@ class BasicCredentialsTests(unittest2.TestCase):
             self.assertEqual(self.credentials.id_token, body)
 
 
-class AccessTokenCredentialsTests(unittest2.TestCase):
+class AccessTokenCredentialsTests(unittest.TestCase):
 
     def setUp(self):
         access_token = 'foo'
@@ -1519,7 +1519,7 @@ class AccessTokenCredentialsTests(unittest2.TestCase):
         self.assertEqual(b'Bearer foo', content[b'Authorization'])
 
 
-class TestAssertionCredentials(unittest2.TestCase):
+class TestAssertionCredentials(unittest.TestCase):
     assertion_text = 'This is the assertion'
     assertion_type = 'http://www.google.com/assertionType'
 
@@ -1570,7 +1570,7 @@ class TestAssertionCredentials(unittest2.TestCase):
             credentials.sign_blob(b'blob')
 
 
-class UpdateQueryParamsTest(unittest2.TestCase):
+class UpdateQueryParamsTest(unittest.TestCase):
     def test_update_query_params_no_params(self):
         uri = 'http://www.google.com'
         updated = client._update_query_params(uri, {'a': 'b'})
@@ -1583,7 +1583,7 @@ class UpdateQueryParamsTest(unittest2.TestCase):
         assertUrisEqual(self, updated, hardcoded_update)
 
 
-class ExtractIdTokenTest(unittest2.TestCase):
+class ExtractIdTokenTest(unittest.TestCase):
     """Tests client._extract_id_token()."""
 
     def test_extract_success(self):
@@ -1604,7 +1604,7 @@ class ExtractIdTokenTest(unittest2.TestCase):
             client._extract_id_token(jwt)
 
 
-class OAuth2WebServerFlowTest(unittest2.TestCase):
+class OAuth2WebServerFlowTest(unittest.TestCase):
 
     def setUp(self):
         self.flow = client.OAuth2WebServerFlow(
@@ -2030,7 +2030,7 @@ class OAuth2WebServerFlowTest(unittest2.TestCase):
         self.assertEqual(credentials.id_token, body)
 
 
-class FlowFromCachedClientsecrets(unittest2.TestCase):
+class FlowFromCachedClientsecrets(unittest.TestCase):
 
     def test_flow_from_clientsecrets_cached(self):
         cache_mock = http_mock.CacheMock()
@@ -2136,7 +2136,7 @@ class FlowFromCachedClientsecrets(unittest2.TestCase):
         loadfile_mock.assert_called_once_with(filename, cache=cache)
 
 
-class CredentialsFromCodeTests(unittest2.TestCase):
+class CredentialsFromCodeTests(unittest.TestCase):
 
     def setUp(self):
         self.client_id = 'client_id_abc'
@@ -2203,7 +2203,7 @@ class CredentialsFromCodeTests(unittest2.TestCase):
                 self.code, http=http)
 
 
-class Test__save_private_file(unittest2.TestCase):
+class Test__save_private_file(unittest.TestCase):
 
     def _save_helper(self, filename):
         contents = []
@@ -2231,7 +2231,7 @@ class Test__save_private_file(unittest2.TestCase):
         self._save_helper(filename)
 
 
-class Test__get_application_default_credential_GAE(unittest2.TestCase):
+class Test__get_application_default_credential_GAE(unittest.TestCase):
 
     @mock.patch.dict('sys.modules', {
         'oauth2client.contrib.appengine': mock.Mock()})
@@ -2244,7 +2244,7 @@ class Test__get_application_default_credential_GAE(unittest2.TestCase):
         creds_kls.assert_called_once_with([])
 
 
-class Test__get_application_default_credential_GCE(unittest2.TestCase):
+class Test__get_application_default_credential_GCE(unittest.TestCase):
 
     @mock.patch.dict('sys.modules', {
         'oauth2client.contrib.gce': mock.Mock()})
@@ -2257,7 +2257,7 @@ class Test__get_application_default_credential_GCE(unittest2.TestCase):
         creds_kls.assert_called_once_with()
 
 
-class Test__require_crypto_or_die(unittest2.TestCase):
+class Test__require_crypto_or_die(unittest.TestCase):
 
     @mock.patch.object(client, 'HAS_CRYPTO', new=True)
     def test_with_crypto(self):
@@ -2269,7 +2269,7 @@ class Test__require_crypto_or_die(unittest2.TestCase):
             client._require_crypto_or_die()
 
 
-class TestDeviceFlowInfo(unittest2.TestCase):
+class TestDeviceFlowInfo(unittest.TestCase):
 
     DEVICE_CODE = 'e80ff179-fd65-416c-9dbf-56a23e5d23e4'
     USER_CODE = '4bbd8b82-fc73-11e5-adf3-00c2c63e5792'

--- a/tests/test_clientsecrets.py
+++ b/tests/test_clientsecrets.py
@@ -18,8 +18,7 @@ import errno
 from io import StringIO
 import os
 import tempfile
-
-import unittest2
+import unittest
 
 import oauth2client
 from oauth2client import _helpers
@@ -36,7 +35,7 @@ NONEXISTENT_FILE = os.path.join(
     os.path.dirname(__file__), 'afilethatisntthere.json')
 
 
-class Test__validate_clientsecrets(unittest2.TestCase):
+class Test__validate_clientsecrets(unittest.TestCase):
 
     def test_with_none(self):
         with self.assertRaises(clientsecrets.InvalidClientSecretsError):
@@ -147,7 +146,7 @@ class Test__validate_clientsecrets(unittest2.TestCase):
         self.assertEqual(result, (clientsecrets.TYPE_INSTALLED, client_info))
 
 
-class Test__loadfile(unittest2.TestCase):
+class Test__loadfile(unittest.TestCase):
 
     def test_success(self):
         client_type, client_info = clientsecrets._loadfile(VALID_FILE)
@@ -176,7 +175,7 @@ class Test__loadfile(unittest2.TestCase):
             clientsecrets._loadfile(filename)
 
 
-class OAuth2CredentialsTests(unittest2.TestCase):
+class OAuth2CredentialsTests(unittest.TestCase):
 
     def test_validate_error(self):
         payload = (
@@ -223,7 +222,7 @@ class OAuth2CredentialsTests(unittest2.TestCase):
         self.assertEquals(exc_manager.exception.args[3], errno.ENOENT)
 
 
-class CachedClientsecretsTests(unittest2.TestCase):
+class CachedClientsecretsTests(unittest.TestCase):
 
     class CacheMock(object):
         def __init__(self):

--- a/tests/test_crypt.py
+++ b/tests/test_crypt.py
@@ -14,9 +14,9 @@
 
 import base64
 import os
+import unittest
 
 import mock
-import unittest2
 
 from oauth2client import _helpers
 from oauth2client import client
@@ -33,14 +33,14 @@ def datafile(filename):
         return file_obj.read()
 
 
-class Test__bad_pkcs12_key_as_pem(unittest2.TestCase):
+class Test__bad_pkcs12_key_as_pem(unittest.TestCase):
 
     def test_fails(self):
         with self.assertRaises(NotImplementedError):
             crypt._bad_pkcs12_key_as_pem()
 
 
-class Test_pkcs12_key_as_pem(unittest2.TestCase):
+class Test_pkcs12_key_as_pem(unittest.TestCase):
 
     def _make_svc_account_creds(self, private_key_file='privatekey.p12'):
         filename = data_filename(private_key_file)
@@ -72,7 +72,7 @@ class Test_pkcs12_key_as_pem(unittest2.TestCase):
         self._succeeds_helper(password)
 
 
-class Test__verify_signature(unittest2.TestCase):
+class Test__verify_signature(unittest.TestCase):
 
     def test_success_single_cert(self):
         cert_value = 'cert-value'
@@ -144,7 +144,7 @@ class Test__verify_signature(unittest2.TestCase):
             verifier.verify.assert_called_once_with(message, signature)
 
 
-class Test__check_audience(unittest2.TestCase):
+class Test__check_audience(unittest.TestCase):
 
     def test_null_audience(self):
         result = crypt._check_audience(None, None)
@@ -172,7 +172,7 @@ class Test__check_audience(unittest2.TestCase):
             crypt._check_audience(payload_dict, audience2)
 
 
-class Test__verify_time_range(unittest2.TestCase):
+class Test__verify_time_range(unittest.TestCase):
 
     def _exception_helper(self, payload_dict):
         exception_caught = None
@@ -256,7 +256,7 @@ class Test__verify_time_range(unittest2.TestCase):
             self.assertEqual(exception_caught, None)
 
 
-class Test_verify_signed_jwt_with_certs(unittest2.TestCase):
+class Test_verify_signed_jwt_with_certs(unittest.TestCase):
 
     def test_jwt_no_segments(self):
         exception_caught = None

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -24,12 +24,12 @@ import os
 import pickle
 import stat
 import tempfile
+import unittest
 import warnings
 
 import mock
 import six
 from six.moves import http_client
-import unittest2
 
 from oauth2client import _helpers
 from oauth2client import client
@@ -48,7 +48,7 @@ _filehandle, FILENAME = tempfile.mkstemp('oauth2client_test.data')
 os.close(_filehandle)
 
 
-class OAuth2ClientFileTests(unittest2.TestCase):
+class OAuth2ClientFileTests(unittest.TestCase):
 
     def tearDown(self):
         try:
@@ -95,7 +95,7 @@ class OAuth2ClientFileTests(unittest2.TestCase):
         finally:
             os.rmdir(FILENAME)
 
-    @unittest2.skipIf(not hasattr(os, 'symlink'), 'No symlink available')
+    @unittest.skipIf(not hasattr(os, 'symlink'), 'No symlink available')
     def test_no_sym_link_credentials(self):
         SYMFILENAME = FILENAME + '.sym'
         os.symlink(FILENAME, SYMFILENAME)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -17,9 +17,9 @@
 import os
 import tempfile
 import time
+import unittest
 
 import mock
-import unittest2
 
 from oauth2client import _helpers
 from oauth2client import client
@@ -47,7 +47,7 @@ def datafile(filename):
         return file_obj.read()
 
 
-class CryptTests(unittest2.TestCase):
+class CryptTests(unittest.TestCase):
 
     def setUp(self):
         self.format_ = 'p12'
@@ -232,7 +232,7 @@ class PEMCryptTestsOpenSSL(CryptTests):
         self.verifier = crypt.OpenSSLVerifier
 
 
-class SignedJwtAssertionCredentialsTests(unittest2.TestCase):
+class SignedJwtAssertionCredentialsTests(unittest.TestCase):
 
     def setUp(self):
         self.orig_signer = crypt.Signer
@@ -334,7 +334,7 @@ class PEMSignedJwtAssertionCredentialsPyCryptoTests(
         crypt.Signer = self.orig_signer
 
 
-class TestHasOpenSSLFlag(unittest2.TestCase):
+class TestHasOpenSSLFlag(unittest.TestCase):
 
     def test_true(self):
         self.assertEqual(True, client.HAS_OPENSSL)

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -21,12 +21,12 @@ import datetime
 import json
 import os
 import tempfile
+import unittest
 
 import mock
 import rsa
 import six
 from six.moves import http_client
-import unittest2
 
 from oauth2client import client
 from oauth2client import crypt
@@ -44,7 +44,7 @@ def datafile(filename):
         return file_obj.read()
 
 
-class ServiceAccountCredentialsTests(unittest2.TestCase):
+class ServiceAccountCredentialsTests(unittest.TestCase):
 
     def setUp(self):
         self.orig_signer = crypt.Signer
@@ -386,7 +386,7 @@ T3_EXPIRY = T3 + TOKEN_LIFE
 T3_EXPIRY_DATE = T3_DATE + datetime.timedelta(seconds=TOKEN_LIFE)
 
 
-class JWTAccessCredentialsTests(unittest2.TestCase):
+class JWTAccessCredentialsTests(unittest.TestCase):
 
     def setUp(self):
         self.client_id = '123'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,24 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import socket
 import sys
 import threading
+import unittest
 
 import mock
 from six.moves.urllib import request
-import unittest2
 
 from oauth2client import client
 from oauth2client import tools
 
-try:
-    import argparse
-except ImportError:  # pragma: NO COVER
-    raise unittest2.SkipTest('argparase unavailable.')
 
-
-class TestClientRedirectServer(unittest2.TestCase):
+class TestClientRedirectServer(unittest.TestCase):
     """Test the ClientRedirectServer and ClientRedirectHandler classes."""
 
     def test_ClientRedirectServer(self):
@@ -51,7 +47,7 @@ class TestClientRedirectServer(unittest2.TestCase):
         self.assertEqual(httpd.query_params.get('code'), code)
 
 
-class TestRunFlow(unittest2.TestCase):
+class TestRunFlow(unittest.TestCase):
 
     def setUp(self):
         self.server = mock.Mock()
@@ -187,6 +183,6 @@ class TestRunFlow(unittest2.TestCase):
         self.assertFalse(self.server.handle_request.called)
 
 
-class TestMessageIfMissing(unittest2.TestCase):
+class TestMessageIfMissing(unittest.TestCase):
     def test_message_if_missing(self):
         self.assertIn('somefile.txt', tools.message_if_missing('somefile.txt'))

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import httplib2
 import mock
-import unittest2
 
 from oauth2client import client
 from oauth2client import transport
 from . import http_mock
 
 
-class TestMemoryCache(unittest2.TestCase):
+class TestMemoryCache(unittest.TestCase):
 
     def test_get_set_delete(self):
         cache = transport.MemoryCache()
@@ -33,7 +34,7 @@ class TestMemoryCache(unittest2.TestCase):
         self.assertIsNone(cache.get('foo'))
 
 
-class Test_get_cached_http(unittest2.TestCase):
+class Test_get_cached_http(unittest.TestCase):
 
     def test_global(self):
         cached_http = transport.get_cached_http()
@@ -47,7 +48,7 @@ class Test_get_cached_http(unittest2.TestCase):
         self.assertIs(result, cache)
 
 
-class Test_get_http_object(unittest2.TestCase):
+class Test_get_http_object(unittest.TestCase):
 
     @mock.patch.object(httplib2, 'Http', return_value=object())
     def test_it(self, http_klass):
@@ -62,7 +63,7 @@ class Test_get_http_object(unittest2.TestCase):
         http_klass.assert_called_once_with(1, 2, foo='bar')
 
 
-class Test__initialize_headers(unittest2.TestCase):
+class Test__initialize_headers(unittest.TestCase):
 
     def test_null(self):
         result = transport._initialize_headers(None)
@@ -75,7 +76,7 @@ class Test__initialize_headers(unittest2.TestCase):
         self.assertIsNot(result, headers)
 
 
-class Test__apply_user_agent(unittest2.TestCase):
+class Test__apply_user_agent(unittest.TestCase):
 
     def test_null(self):
         headers = object()
@@ -99,7 +100,7 @@ class Test__apply_user_agent(unittest2.TestCase):
         self.assertEqual(result, {'user-agent': final_agent})
 
 
-class Test_clean_headers(unittest2.TestCase):
+class Test_clean_headers(unittest.TestCase):
 
     def test_no_modify(self):
         headers = {b'key': b'val'}
@@ -127,7 +128,7 @@ class Test_clean_headers(unittest2.TestCase):
         self.assertEqual(result, header_str)
 
 
-class Test_wrap_http_for_auth(unittest2.TestCase):
+class Test_wrap_http_for_auth(unittest.TestCase):
 
     def test_wrap(self):
         credentials = object()
@@ -139,7 +140,7 @@ class Test_wrap_http_for_auth(unittest2.TestCase):
         self.assertIs(http.request.credentials, credentials)
 
 
-class Test_request(unittest2.TestCase):
+class Test_request(unittest.TestCase):
 
     uri = 'http://localhost'
     method = 'POST'

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ basedeps = mock>=1.3.0
            webtest
            pytest
            flask
-           unittest2
            sqlalchemy
            fasteners
 deps = {[testenv]basedeps}
@@ -102,7 +101,6 @@ commands =
     python {toxinidir}/scripts/run_gce_system_tests.py
 deps =
     pycrypto>=2.6
-    unittest2
 passenv = {[testenv:system-tests]passenv}
 
 [testenv:flake8]


### PR DESCRIPTION
No longer needed since Python 2.6 support has been dropped.

Fixes #609

/cc @pferate 
