### PR TITLE
Correct query loss when using parse_qsl to dict

### DIFF
--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -122,16 +122,16 @@ class ClientRedirectHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         if an error occurred.
         """
         self.send_response(http_client.OK)
-        self.send_header("Content-type", "text/html")
+        self.send_header('Content-type', 'text/html')
         self.end_headers()
-        query = self.path.split('?', 1)[-1]
-        query = dict(urllib.parse.parse_qsl(query))
+        parts = urllib.parse.urlparse(self.path)
+        query = _helpers.parse_unique_urlencoded(parts.query)
         self.server.query_params = query
         self.wfile.write(
-            b"<html><head><title>Authentication Status</title></head>")
+            b'<html><head><title>Authentication Status</title></head>')
         self.wfile.write(
-            b"<body><p>The authentication flow has completed.</p>")
-        self.wfile.write(b"</body></html>")
+            b'<body><p>The authentication flow has completed.</p>')
+        self.wfile.write(b'</body></html>')
 
     def log_message(self, format, *args):
         """Do not log messages to stdout while running as cmd. line program."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1364,7 +1364,7 @@ class BasicCredentialsTests(unittest.TestCase):
             self.assertEqual(credentials.scopes, set())
             self.assertEqual(exc_manager.exception.args, (error_msg,))
 
-        token_uri = client._update_query_params(
+        token_uri = _helpers.update_query_params(
             oauth2client.GOOGLE_TOKEN_INFO_URI,
             {'fields': 'scope', 'access_token': token})
 
@@ -1558,19 +1558,6 @@ class TestAssertionCredentials(unittest.TestCase):
             credentials.sign_blob(b'blob')
 
 
-class UpdateQueryParamsTest(unittest.TestCase):
-    def test_update_query_params_no_params(self):
-        uri = 'http://www.google.com'
-        updated = client._update_query_params(uri, {'a': 'b'})
-        self.assertEqual(updated, uri + '?a=b')
-
-    def test_update_query_params_existing_params(self):
-        uri = 'http://www.google.com?x=y'
-        updated = client._update_query_params(uri, {'a': 'b', 'c': 'd&'})
-        hardcoded_update = uri + '&a=b&c=d%26'
-        assertUrisEqual(self, updated, hardcoded_update)
-
-
 class ExtractIdTokenTest(unittest.TestCase):
     """Tests client._extract_id_token()."""
 
@@ -1670,7 +1657,7 @@ class OAuth2WebServerFlowTest(unittest.TestCase):
             'access_type': 'offline',
             'response_type': 'code',
         }
-        expected = client._update_query_params(flow.auth_uri, query_params)
+        expected = _helpers.update_query_params(flow.auth_uri, query_params)
         assertUrisEqual(self, expected, result)
         # Check stubs.
         self.assertEqual(logger.warning.call_count, 1)
@@ -1735,7 +1722,7 @@ class OAuth2WebServerFlowTest(unittest.TestCase):
             'access_type': 'offline',
             'response_type': 'code',
         }
-        expected = client._update_query_params(flow.auth_uri, query_params)
+        expected = _helpers.update_query_params(flow.auth_uri, query_params)
         assertUrisEqual(self, expected, result)
 
     def test_step1_get_device_and_user_codes_wo_device_uri(self):


### PR DESCRIPTION
**NOTE**: I noticed this when doing a fairly comprehensive source check to find the `httplib2` footprint (for #128).

The issue is that repeated params could just be dropped:

``` python
>>> from six.moves import urllib
>>> params_list = urllib.parse.parse_qsl('a=1&a=2')
>>> params_list
[('a', '1'), ('a', '2')]
>>> dict(params_list)
{'a': '2'}
```
