### PR TITLE
Missing sys.argv edge case (embedded Python)

### DIFF
--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -76,7 +76,11 @@ Go to the following link in your browser:
 
 def _CreateArgumentParser():
     try:
-        import argparse
+        # Edge case when call is from embedded Python and sys.argv is not defined.
+        if hasattr(sys, 'argv'):
+            import argparse
+        else:
+            return None
     except ImportError:  # pragma: NO COVER
         return None
     parser = argparse.ArgumentParser(add_help=False)

--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -76,7 +76,7 @@ Go to the following link in your browser:
 
 def _CreateArgumentParser():
     try:
-        # Edge case when call is from embedded Python and sys.argv is not defined.
+        # Edge case when call from embedded Python (sys.argv not defined).
         if hasattr(sys, 'argv'):
             import argparse
         else:


### PR DESCRIPTION
When the library is called from embedded Python (e.g. inside a C program), sys.argv is not defined which makes the library misbehave.
The fix check that sys.argv is defined before it imports argparse; it returns None otherwise.

I am using oauth2client with Postgres/Multicorn which calls Python from inside C extensions.
