### PR TITLE
Store original encoded and signed identity JWT in OAuth2Credentials

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -451,7 +451,7 @@ class OAuth2Credentials(Credentials):
     def __init__(self, access_token, client_id, client_secret, refresh_token,
                  token_expiry, token_uri, user_agent, revoke_uri=None,
                  id_token=None, token_response=None, scopes=None,
-                 token_info_uri=None):
+                 token_info_uri=None, id_token_jwt=None):
         """Create an instance of OAuth2Credentials.
 
         This constructor is not usually called by the user, instead
@@ -493,6 +493,7 @@ class OAuth2Credentials(Credentials):
         self.user_agent = user_agent
         self.revoke_uri = revoke_uri
         self.id_token = id_token
+        self.id_token_jwt = id_token_jwt
         self.token_response = token_response
         self.scopes = set(_helpers.string_to_scopes(scopes or []))
         self.token_info_uri = token_info_uri
@@ -621,6 +622,7 @@ class OAuth2Credentials(Credentials):
             data['user_agent'],
             revoke_uri=data.get('revoke_uri', None),
             id_token=data.get('id_token', None),
+            id_token_jwt=data.get('id_token_jwt', None),
             token_response=data.get('token_response', None),
             scopes=data.get('scopes', None),
             token_info_uri=data.get('token_info_uri', None))
@@ -786,8 +788,10 @@ class OAuth2Credentials(Credentials):
                 self.token_expiry = None
             if 'id_token' in d:
                 self.id_token = _extract_id_token(d['id_token'])
+                self.id_token_jwt = d['id_token']
             else:
                 self.id_token = None
+                self.id_token_jwt = None
             # On temporary refresh errors, the user does not actually have to
             # re-authorize, so we unflag here.
             self.invalid = False
@@ -2059,15 +2063,17 @@ class OAuth2WebServerFlow(Flow):
                 token_expiry = delta + _UTCNOW()
 
             extracted_id_token = None
+            id_token_jwt = None
             if 'id_token' in d:
                 extracted_id_token = _extract_id_token(d['id_token'])
+                id_token_jwt = d['id_token']
 
             logger.info('Successfully retrieved access token')
             return OAuth2Credentials(
                 access_token, self.client_id, self.client_secret,
                 refresh_token, token_expiry, self.token_uri, self.user_agent,
                 revoke_uri=self.revoke_uri, id_token=extracted_id_token,
-                token_response=d, scopes=self.scope,
+                id_token_jwt=id_token_jwt, token_response=d, scopes=self.scope,
                 token_info_uri=self.token_info_uri)
         else:
             logger.info('Failed to retrieve access token: %s', content)

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -474,8 +474,11 @@ class OAuth2Credentials(Credentials):
                             because some providers (e.g. wordpress.com) include
                             extra fields that clients may want.
             scopes: list, authorized scopes for these credentials.
-          token_info_uri: string, the URI for the token info endpoint. Defaults
-                          to None; scopes can not be refreshed if this is None.
+            token_info_uri: string, the URI for the token info endpoint.
+                            Defaults to None; scopes can not be refreshed if
+                            this is None.
+            id_token_jwt: string, the encoded and signed identity JWT. The
+                          decoded version of this is stored in id_token.
 
         Notes:
             store: callable, A callable that when passed a Credential

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1479,6 +1479,7 @@ class BasicCredentialsTests(unittest.TestCase):
             http = self.credentials.authorize(http)
             resp, content = transport.request(http, 'http://example.com')
             self.assertEqual(self.credentials.id_token, body)
+            self.assertEqual(self.credentials.id_token_jwt, jwt)
 
 
 class AccessTokenCredentialsTests(unittest.TestCase):
@@ -2085,6 +2086,7 @@ class OAuth2WebServerFlowTest(unittest.TestCase):
         credentials = self.flow.step2_exchange(code='some random code',
                                                http=http)
         self.assertEqual(credentials.id_token, body)
+        self.assertEqual(credentials.id_token_jwt, jwt)
 
 
 class FlowFromCachedClientsecrets(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1479,7 +1479,7 @@ class BasicCredentialsTests(unittest.TestCase):
             http = self.credentials.authorize(http)
             resp, content = transport.request(http, 'http://example.com')
             self.assertEqual(self.credentials.id_token, body)
-            self.assertEqual(self.credentials.id_token_jwt, jwt)
+            self.assertEqual(self.credentials.id_token_jwt, jwt.decode())
 
 
 class AccessTokenCredentialsTests(unittest.TestCase):
@@ -2086,7 +2086,7 @@ class OAuth2WebServerFlowTest(unittest.TestCase):
         credentials = self.flow.step2_exchange(code='some random code',
                                                http=http)
         self.assertEqual(credentials.id_token, body)
-        self.assertEqual(credentials.id_token_jwt, jwt)
+        self.assertEqual(credentials.id_token_jwt, jwt.decode())
 
 
 class FlowFromCachedClientsecrets(unittest.TestCase):


### PR DESCRIPTION
For some authorization flows, including the Auth0 Delegation flow, the endpoint requires the original signed identity JWT to be sent. To support this, it is necessary to store the JWT alongside the decoded content.

This PR adds id_token_jwt as an element in the OAuth2Credentials. It also adds the logic to populate that element in parts of the flows that receive the identity token.

(This is the second PR for this as a previous PR had bad commit email addresses and was closed.)

Resolves: #678