### PR TITLE
Remove b64 padding from PKCE values, per RFC7636

### DIFF
--- a/oauth2client/_pkce.py
+++ b/oauth2client/_pkce.py
@@ -38,7 +38,7 @@ def code_verifier(n_bytes=64):
     Returns:
         Bytestring, representing urlsafe base64-encoded random data.
     """
-    verifier = base64.urlsafe_b64encode(os.urandom(n_bytes))
+    verifier = base64.urlsafe_b64encode(os.urandom(n_bytes)).rstrip(b'=')
     # https://tools.ietf.org/html/rfc7636#section-4.1
     # minimum length of 43 characters and a maximum length of 128 characters.
     if len(verifier) < 43:
@@ -60,6 +60,8 @@ def code_challenge(verifier):
             code_verifier().
 
     Returns:
-        Bytestring, representing a urlsafe base64-encoded sha256 hash digest.
+        Bytestring, representing a urlsafe base64-encoded sha256 hash digest,
+            without '=' padding.
     """
-    return base64.urlsafe_b64encode(hashlib.sha256(verifier).digest())
+    digest = hashlib.sha256(verifier).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b'=')

--- a/tests/test__pkce.py
+++ b/tests/test__pkce.py
@@ -33,7 +33,7 @@ class PKCETests(unittest.TestCase):
         fake_urandom.return_value = canned_randomness
         expected = (
             b'mBBEN_O3qvzd003ioywGoLCptI_L0PWGTjJwjF0hV5rt'
-            b'NTSZnY12XKcvgfNKmMOQ7rCMt1pjIwVNME8I2gkfBw=='
+            b'NTSZnY12XKcvgfNKmMOQ7rCMt1pjIwVNME8I2gkfBw'
         )
         result = _pkce.code_verifier()
         self.assertEqual(result, expected)
@@ -50,5 +50,5 @@ class PKCETests(unittest.TestCase):
 
     def test_challenge(self):
         result = _pkce.code_challenge(b'SOME_VERIFIER')
-        expected = b'6xJCQsjTtS3zjUwd8_ZqH0SyviGHnp5PsHXWKOCqDuI='
+        expected = b'6xJCQsjTtS3zjUwd8_ZqH0SyviGHnp5PsHXWKOCqDuI'
         self.assertEqual(result, expected)


### PR DESCRIPTION
Fixes #674 