### PR TITLE
Make `tox -e flake8` pass.

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -38,7 +38,7 @@ from tests import http_mock
 try:
     # Python2
     from future_builtins import oct
-except:  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
     pass
 
 _filehandle, FILENAME = tempfile.mkstemp('oauth2client_test.data')

--- a/tox.ini
+++ b/tox.ini
@@ -110,3 +110,7 @@ putty-ignore =
   # Ignore lines over 80 chars that include "http:" or "https:"
   /http:/ : E501
   /https:/ : E501
+  # E722 do not use bare except
+  # Existing sloppy usages.
+  oauth2client/crypt.py : E722
+  oauth2client/contrib/multiprocess_file_storage.py : E722


### PR DESCRIPTION
This library is in maintenance mode, but no reason to leave travis broken. Two
disables and a better `except` in a test and it's green again.

PTAL @jonparrott @dhermes 