### PR TITLE
Pass prompt='consent' from flow_from_clientsecrets

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -2092,7 +2092,7 @@ class OAuth2WebServerFlow(Flow):
 @_helpers.positional(2)
 def flow_from_clientsecrets(filename, scope, redirect_uri=None,
                             message=None, cache=None, login_hint=None,
-                            device_uri=None, pkce=None, code_verifier=None, 
+                            device_uri=None, pkce=None, code_verifier=None,
                             prompt=None):
     """Create a Flow from a clientsecrets file.
 
@@ -2142,7 +2142,13 @@ def flow_from_clientsecrets(filename, scope, redirect_uri=None,
                 'login_hint': login_hint,
             }
             revoke_uri = client_info.get('revoke_uri')
-            optional = ('revoke_uri', 'device_uri', 'pkce', 'code_verifier', 'prompt')
+            optional = (
+                'revoke_uri',
+                'device_uri',
+                'pkce',
+                'code_verifier',
+                'prompt'
+            )
             for param in optional:
                 if locals()[param] is not None:
                     constructor_kwargs[param] = locals()[param]

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -2092,7 +2092,8 @@ class OAuth2WebServerFlow(Flow):
 @_helpers.positional(2)
 def flow_from_clientsecrets(filename, scope, redirect_uri=None,
                             message=None, cache=None, login_hint=None,
-                            device_uri=None, pkce=None, code_verifier=None):
+                            device_uri=None, pkce=None, code_verifier=None, 
+                            prompt=None):
     """Create a Flow from a clientsecrets file.
 
     Will create the right kind of Flow based on the contents of the
@@ -2141,7 +2142,7 @@ def flow_from_clientsecrets(filename, scope, redirect_uri=None,
                 'login_hint': login_hint,
             }
             revoke_uri = client_info.get('revoke_uri')
-            optional = ('revoke_uri', 'device_uri', 'pkce', 'code_verifier')
+            optional = ('revoke_uri', 'device_uri', 'pkce', 'code_verifier', 'prompt')
             for param in optional:
                 if locals()[param] is not None:
                     constructor_kwargs[param] = locals()[param]


### PR DESCRIPTION
Currently there is no way to create an OAuth2WebServerFlow with a prompt argument using the flow_from_clientsecrets. Meaning developers must either call internal methods to add the prompt='consent' or read the client_secrets json themselves (so they can call the OAuth2WebServerFlow initializer themselves).

While this repository is technically deprecated, it is still pointed to by the official docs: https://developers.google.com/api-client-library/python/guide/aaa_oauth

**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
