### PR TITLE
Release v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v4.2.0
+## v4.1.1
 
 **Note**: oauth2client is deprecated. No more features will be added to the
 libraries and the core team is turning down support. We recommend you use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v4.2.0
+
+**Note**: oauth2client is deprecated. No more features will be added to the
+libraries and the core team is turning down support. We recommend you use
+[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
+
+New features:
+* Allow passing prompt='consent' via the flow_from_clientsecrets. (#717)
+
 ## v4.1.0
 
 **Note**: oauth2client is now deprecated. No more features will be added to the

--- a/oauth2client/__init__.py
+++ b/oauth2client/__init__.py
@@ -14,7 +14,7 @@
 
 """Client library for using OAuth2, especially with Google APIs."""
 
-__version__ = '4.1.0'
+__version__ = '4.2.0'
 
 GOOGLE_AUTH_URI = 'https://accounts.google.com/o/oauth2/v2/auth'
 GOOGLE_DEVICE_URI = 'https://accounts.google.com/o/oauth2/device/code'

--- a/oauth2client/__init__.py
+++ b/oauth2client/__init__.py
@@ -14,7 +14,7 @@
 
 """Client library for using OAuth2, especially with Google APIs."""
 
-__version__ = '4.2.0'
+__version__ = '4.1.1'
 
 GOOGLE_AUTH_URI = 'https://accounts.google.com/o/oauth2/v2/auth'
 GOOGLE_DEVICE_URI = 'https://accounts.google.com/o/oauth2/device/code'


### PR DESCRIPTION
**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
