### PR TITLE
Exclude test in find_packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include README.md
-include LICENSE
-recursive-exclude tests *
+include README.md LICENSE CHANGELOG.md
+recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     author_email='jonwayne+oauth2client@google.com',
     url='http://github.com/google/oauth2client/',
     install_requires=install_requires,
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests*',)),
     license='Apache 2.0',
     keywords='google oauth 2.0 http client',
     classifiers=[


### PR DESCRIPTION
To avoid conflicts with projects that have tests in their top-level
directory:

* exlude tests in find_packages
* add include in MANIFEST.in

Closes: #688

Signed-off-by: Spyros Trigazis <spyridon.trigazis@cern.ch>

**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
