### PR TITLE
Don't use socket.recv with socket.MSG_WAITALL

### DIFF
--- a/oauth2client/_helpers.py
+++ b/oauth2client/_helpers.py
@@ -339,3 +339,16 @@ def _urlsafe_b64decode(b64string):
     b64string = _to_bytes(b64string)
     padded = b64string + b'=' * (4 - len(b64string) % 4)
     return base64.urlsafe_b64decode(padded)
+
+
+def _recvall(sock, size):
+    buffer = bytearray(size)
+    view = memoryview(buffer)
+    pos = 0
+    while pos < size:
+        read = sock.recv_into(view[pos:], size - pos)
+        if not read:
+            raise EOFError("%s bytes read on a total of %s expected bytes"
+                           % (pos, size))
+        pos += read
+    return bytes(buffer)

--- a/oauth2client/contrib/devshell.py
+++ b/oauth2client/contrib/devshell.py
@@ -89,7 +89,7 @@ def _SendRecv():
     len_str, json_str = header.split('\n', 1)
     to_read = int(len_str) - len(json_str)
     if to_read > 0:
-        json_str += sock.recv(to_read, socket.MSG_WAITALL).decode()
+        json_str += _helpers._recvall(sock, to_read).decode()
 
     return CredentialInfoResponse(json_str)
 

--- a/tests/contrib/test_devshell.py
+++ b/tests/contrib/test_devshell.py
@@ -157,7 +157,7 @@ class _AuthReferenceServer(threading.Thread):
             to_read = n - len(extra)
             if to_read > 0:
                 resp_buffer += _helpers._from_bytes(
-                    s.recv(to_read, socket.MSG_WAITALL))
+                    _helpers._recvall(s, to_read))
             if resp_buffer != devshell.CREDENTIAL_INFO_REQUEST_JSON:
                 self.bad_request = True
             response_len = len(self.response)
@@ -190,7 +190,7 @@ class DevshellCredentialsTests(unittest.TestCase):
             header = sock.recv(6).decode()
             len_str, result = header.split('\n', 1)
             to_read = int(len_str) - len(result)
-            result += sock.recv(to_read, socket.MSG_WAITALL).decode()
+            result += _helpers._recvall(sock, to_read).decode()
 
         self.assertTrue(auth_server.bad_request)
         self.assertEqual(result, response_message)


### PR DESCRIPTION
socket.MSG_WAITALL is not available on Windows so the call to
socket.recv with this flag will fail there. Provide a helper method
that tries to receive an exact number of bytes and use it instead.