### PR TITLE
Django 2 urlresolvers issue

### DIFF
--- a/oauth2client/contrib/django_util/__init__.py
+++ b/oauth2client/contrib/django_util/__init__.py
@@ -230,7 +230,7 @@ import importlib
 
 import django.conf
 from django.core import exceptions
-from django.core import urlresolvers
+from django.urls import reverse
 from six.moves.urllib import parse
 
 from oauth2client import clientsecrets
@@ -408,7 +408,7 @@ def _redirect_with_params(url_name, *args, **kwargs):
     Returns:
         A properly formatted redirect string.
     """
-    url = urlresolvers.reverse(url_name, args=args)
+    url = reverse(url_name, args=args)
     params = parse.urlencode(kwargs, True)
     return "{0}?{1}".format(url, params)
 

--- a/oauth2client/contrib/django_util/__init__.py
+++ b/oauth2client/contrib/django_util/__init__.py
@@ -230,7 +230,10 @@ import importlib
 
 import django.conf
 from django.core import exceptions
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except:
+    from django.core import urlresolvers
 from six.moves.urllib import parse
 
 from oauth2client import clientsecrets
@@ -408,7 +411,11 @@ def _redirect_with_params(url_name, *args, **kwargs):
     Returns:
         A properly formatted redirect string.
     """
-    url = reverse(url_name, args=args)
+    try:
+        url = reverse(url_name, args=args)
+    except:
+        url = urlresolvers.reverse(url_name, args=args)
+
     params = parse.urlencode(kwargs, True)
     return "{0}?{1}".format(url, params)
 


### PR DESCRIPTION
**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
