### PR TITLE
Update retrieve_scopes to use field=scope instead of fields=scope

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -883,7 +883,7 @@ class OAuth2Credentials(Credentials):
                    invalid.
         """
         logger.info('Refreshing scopes')
-        query_params = {'access_token': token, 'fields': 'scope'}
+        query_params = {'access_token': token, 'field': 'scope'}
         token_info_uri = _helpers.update_query_params(
             self.token_info_uri, query_params)
         resp, content = transport.request(http, token_info_uri)


### PR DESCRIPTION
**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/). <- Understood

Since yesterday, we started seeing `retrieve_scope` calls error out with 400 from Google. This is the error:
```
{
  "error": {
    "code": 400,
    "message": "Request contains an invalid argument.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "field": "scope",
            "description": "Error expanding 'fields' parameter. Cannot find matching fields for path 'scope'."
          }
        ]
      }
    ]
  }
}
```
Something must have changed such that urls of the form `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=<token>&fields=scope` are rejected with 400 error, but either `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=<token>&field=scope` or `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=<token>&fields[]=scope` fixes it.
