### PR TITLE
Alternative library that is closer to oauth2client API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a client library for accessing resources protected by OAuth 2.0.
 
 **Note**: oauth2client is now deprecated. No more features will be added to the
 libraries and the core team is turning down support. We recommend you use
-[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/). For more details on the deprecation, see [oauth2client deprecation](https://google-auth.readthedocs.io/en/latest/oauth2client-deprecation.html).
+[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/). [google-auth-oauthlib](https://google-auth-oauthlib.readthedocs.io/en/latest/) is an experimental library that provides an API similar to `oauth2client` while using `google-auth` and `oauthlib`. For more details on the deprecation, see [oauth2client deprecation](https://google-auth.readthedocs.io/en/latest/oauth2client-deprecation.html).
 
 Installation
 ============


### PR DESCRIPTION
**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).

I've recently removed oauth2client from a project. It was a struggle to determine how to go about it without having to do a ton of extra work. It took a bit of digging to find `google-auth-oauthlib` and ultimately it drops in fairly nicely, with a lot less work than using google-auth and oauthlib directly .
