### PR TITLE
Fixed typo

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -931,8 +931,8 @@ class AccessTokenCredentials(OAuth2Credentials):
     def __init__(self, access_token, user_agent, revoke_uri=None):
         """Create an instance of OAuth2Credentials
 
-        This is one of the few types of Credentials that you should construct,
-        Credentials objects are usually instantiated by a Flow.
+        This is one of the few types of Credentials that you should 
+        construct, Credentials objects are usually instantiated by a Flow.
 
         Args:
             access_token: string, access token.

--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -931,7 +931,7 @@ class AccessTokenCredentials(OAuth2Credentials):
     def __init__(self, access_token, user_agent, revoke_uri=None):
         """Create an instance of OAuth2Credentials
 
-        This is one of the few types if Credentials that you should contrust,
+        This is one of the few types of Credentials that you should construct,
         Credentials objects are usually instantiated by a Flow.
 
         Args:


### PR DESCRIPTION
Fixed typo in client.py comment

**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
